### PR TITLE
Fix simulate endpoint decorator indentation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-e"""
+"""
 FastAPI backend for the neuropharm simulation lab.
 
 This service exposes a `/simulate` endpoint that accepts a JSON
@@ -105,8 +105,8 @@ def read_root():
 def health():
     return {"status": "ok", "version": "2025.09.05"}
 
-  @app.post("/simulate", response_model=SimulationOutput)
-        tdef simulate(inp: SimulationInput) -> SimulationOutput:
+@app.post("/simulate", response_model=SimulationOutput)
+def simulate(inp: SimulationInput) -> SimulationOutput:
     """Run a single simulation with the provided input.
 
     This function currently implements a highly simplified scoring
@@ -114,8 +114,7 @@ def health():
     5‑HT1B occupancy, modulates it with ADHD state and gut-bias flags,
     and then maps the result into overall "Drive" and "Apathy" scores.
 
-  
-Parameters
+    Parameters
     ----------
     inp : SimulationInput
         The payload specifying receptor occupancies and modifiers.


### PR DESCRIPTION
## Summary
- correct the module docstring opening in `backend/main.py`
- remove stray indentation before the `/simulate` route decorator and fix the function definition
- re-indent the simulate docstring section headings for consistency

## Testing
- python -m compileall backend/main.py

------
https://chatgpt.com/codex/tasks/task_e_68ce26600a548329affbdd464399e527