### PR TITLE
Refine simulation citations model

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,11 @@
-e"""
+"""
 FastAPI backend for the neuropharm simulation lab.
 
 This service exposes a `/simulate` endpoint that accepts a JSON
 payload describing the current receptor occupancy, acute/chronic flags,
 phenotype modifiers (such as ADHD), gut-bias toggles, and other
 parameters. It returns computed scores for motivational drive, apathy
-blunting, and other high‑level readouts.  The current implementation
+blunting, and other high-level readouts.  The current implementation
 provides a simple placeholder model to demonstrate the API and wiring;
 future work should extend this file with a full mechanistic model of
 serotonin, dopamine, glutamate, histamine, and other systems across
@@ -14,43 +14,38 @@ brain regions.
 The API also exposes a root `/` endpoint for a basic health check.
 """
 
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
-from typing import Dict, Any
-from fastapi.middleware.cors import CORSMiddleware
+from __future__ import annotations
 
-
-import numpy as np
-import os
 import json
+import os
+from typing import Any, Dict, List, Optional
 
-from .engine.receptors import get_receptor_weights, get_mechanism_factor, RECEPTORS
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from .engine.receptors import (
+    RECEPTORS,
+    get_mechanism_factor,
+    get_receptor_weights,
+)
+
 
 # -----------------------------------------------------------------------------
 # Pydantic models
 # -----------------------------------------------------------------------------
 
-class ReceptorSpec(BaseModel):
-    """Specification for a single receptor.
 
-    Attributes
-    ----------
-    occ : float
-        Fractional occupancy of the receptor (0.0–1.0).
-    mech : str
-        Mechanism of the ligand ("agonist", "antagonist", "partial", or
-        "inverse").  Future versions may support additional values.
-    """
+class ReceptorSpec(BaseModel):
+    """Specification for a single receptor."""
+
     occ: float
     mech: str
 
 
 class SimulationInput(BaseModel):
-    """Input payload for the simulation.
+    """Input payload for the simulation."""
 
-    Fields are deliberately flexible to allow future extensions
-    (additional neurotransmitters, receptor subtypes, etc.).
-    """
     receptors: Dict[str, ReceptorSpec]
     acute_1a: bool = False
     adhd: bool = False
@@ -58,29 +53,41 @@ class SimulationInput(BaseModel):
     pvt_weight: float = 0.5
 
 
-class SimulationOutput(BaseModel):
-    """Return format from the simulation engine.
+class Citation(BaseModel):
+    """Reference supporting a receptor mechanism."""
 
-    `scores` contains high‑level behavioural metrics normalised to 0–100.
-    `details` includes intermediate values (e.g. computed dopamine phasic
-    drive) that may be useful for debugging or future UI visualisations.
-    `citations` returns a list of PubMed IDs and/or DOIs supporting the
-    mechanisms involved in generating the result.
-    """
+    title: str
+    pmid: Optional[str] = None
+    doi: Optional[str] = None
+
+
+class SimulationOutput(BaseModel):
+    """Return format from the simulation engine."""
+
     scores: Dict[str, float]
     details: Dict[str, Any]
-    citations: Dict[str, list[str]]
+    citations: Dict[str, List[Citation]]
 
 
 # -----------------------------------------------------------------------------
 # Application
 # -----------------------------------------------------------------------------
 
-app = FastAPI(title="Neuropharm Simulation API",
-              description=("Simulate serotonergic, dopaminergic and other\n                           neurotransmitter systems under a variety of\n                           receptor manipulations.  See the README for\n                           details on the expected payload format."))
+
+app = FastAPI(
+    title="Neuropharm Simulation API",
+    description=(
+        "Simulate serotonergic, dopaminergic and other\n"
+        "                           neurotransmitter systems under a variety of\n"
+        "                           receptor manipulations.  See the README for\n"
+        "                           details on the expected payload format."
+    ),
+)
 
 # Configure CORS
-origins = os.environ.get("CORS_ORIGINS", "https://darkfrostx-cmd.github.io").split(",")
+origins = os.environ.get(
+    "CORS_ORIGINS", "https://darkfrostx-cmd.github.io"
+).split(",")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
@@ -91,49 +98,21 @@ app.add_middleware(
 
 
 @app.get("/")
-def read_root():
-    """Health check endpoint.
+def read_root() -> Dict[str, str]:
+    """Health check endpoint."""
 
-    Returns a basic status message so that clients can confirm the API is
-    running.
-    """
     return {"status": "ok", "version": "2025.09.05"}
-
 
 
 @app.get("/health")
-def health():
+def health() -> Dict[str, str]:
     return {"status": "ok", "version": "2025.09.05"}
 
-  @app.post("/simulate", response_model=SimulationOutput)
-        tdef simulate(inp: SimulationInput) -> SimulationOutput:
-    """Run a single simulation with the provided input.
 
-    This function currently implements a highly simplified scoring
-    algorithm. It computes phasic dopamine drive based on 5‑HT2C and
-    5‑HT1B occupancy, modulates it with ADHD state and gut-bias flags,
-    and then maps the result into overall "Drive" and "Apathy" scores.
+@app.post("/simulate", response_model=SimulationOutput)
+def simulate(inp: SimulationInput) -> SimulationOutput:
+    """Run a single simulation with the provided input."""
 
-  
-Parameters
-    ----------
-    inp : SimulationInput
-        The payload specifying receptor occupancies and modifiers.
-
-    Returns
-    -------
-    SimulationOutput
-        A dictionary containing high‑level scores, intermediate details
-        and citations underpinning the mechanisms used.
-    """
-
-    # ---------------------------------------------------------------------
-    # Helper functions
-    #
-    # To support various input naming conventions (e.g. "5HT2C" vs
-    # "5-HT2C"), normalise receptor names by inserting a dash after the
-    # "5" when missing.  This helper returns the canonical key used in
-    # the RECEPTORS mapping.
     def canonical_receptor_name(name: str) -> str:
         if name in RECEPTORS:
             return name
@@ -141,20 +120,18 @@ Parameters
         name_upper = name.upper().replace("HT", "-HT")
         return name_upper
 
-    # Load receptor citations from refs.json.  This file should map
-    # canonical receptor names to lists of PubMed IDs or DOIs.
+    refs_path = os.path.join(os.path.dirname(__file__), "refs.json")
     try:
-        with open(
-            __import__("os").path.join(
-                __import__("os").path.dirname(__file__), "refs.json"
-            ),
-            "r",
-        ) as f:
-            refs = json.load(f)
+        with open(refs_path, "r", encoding="utf-8") as f:
+            refs_raw = json.load(f)
     except FileNotFoundError:
-        refs = {}
+        refs_raw = {}
 
-    # Initialise metric contributions.  Baseline of 50 for each metric.
+    refs: Dict[str, List[Citation]] = {}
+    for rec_name, entries in refs_raw.items():
+        canon_name = canonical_receptor_name(rec_name)
+        refs[canon_name] = [Citation(**entry) for entry in entries]
+
     metrics = [
         "drive",
         "apathy",
@@ -165,64 +142,49 @@ Parameters
     ]
     contrib: Dict[str, float] = {m: 0.0 for m in metrics}
 
-    # Accumulate contributions from each receptor in the input.  For
-    # unknown receptors, silently ignore.  Mechanism factor scales the
-    # per‑unit weight; occupancy scales the contribution.
     for rec_name, spec in inp.receptors.items():
         canon = canonical_receptor_name(rec_name)
         if canon not in RECEPTORS:
             continue
         weights = get_receptor_weights(canon)
         factor = get_mechanism_factor(spec.mech)
-        for m, w in weights.items():
-            contrib[m] += w * spec.occ * factor
+        for metric, weight in weights.items():
+            contrib[metric] += weight * spec.occ * factor
 
-    # Apply phenotype modifiers.  ADHD reduces baseline tone for drive
-    # and motivation; gut_bias attenuates negative contributions (makes
-    # apathy less severe and drive more preserved); acute_1a lowers
-    # overall serotonergic effect (scale contributions down).
     if inp.adhd:
         contrib["drive"] -= 0.3
         contrib["motivation"] -= 0.2
     if inp.gut_bias:
-        for m in metrics:
-            # If contribution is negative, reduce its magnitude by 10%
-            if contrib[m] < 0:
-                contrib[m] *= 0.9
+        for metric in metrics:
+            if contrib[metric] < 0:
+                contrib[metric] *= 0.9
     if inp.acute_1a:
-        for m in metrics:
-            contrib[m] *= 0.75
-    # PVT gating weight scales contributions from 5-HT1B (if present);
-    # approximate by scaling global contributions by (1 - pvt_weight*0.2)
-    contrib_scale = 1.0 - (inp.pvt_weight * 0.2)
-    for m in metrics:
-        contrib[m] *= contrib_scale
+        for metric in metrics:
+            contrib[metric] *= 0.75
 
-    # Convert contributions to scores.  Baseline is 50; each unit of
-    # contribution moves the score by 20 points.  Clamp between 0 and
-    # 100.  Note: for apathy, higher contribution increases apathy; for
-    # other metrics, contributions add directly.
+    contrib_scale = 1.0 - (inp.pvt_weight * 0.2)
+    for metric in metrics:
+        contrib[metric] *= contrib_scale
+
     scores: Dict[str, float] = {}
-    for m in metrics:
+    for metric in metrics:
         base = 50.0
-        change = 20.0 * contrib[m]
-        val = base + change
-        # Invert apathy into ApathyBlunting (higher apathy = lower score)
-        if m == "apathy":
-            val = 100.0 - val
-        scores_name = {
+        change = 20.0 * contrib[metric]
+        value = base + change
+        if metric == "apathy":
+            value = 100.0 - value
+        score_key = {
             "drive": "DriveInvigoration",
             "apathy": "ApathyBlunting",
             "motivation": "Motivation",
             "cognitive_flexibility": "CognitiveFlexibility",
             "anxiety": "Anxiety",
             "sleep_quality": "SleepQuality",
-        }[m]
-        scores[scores_name] = max(0.0, min(100.0, val))
+        }[metric]
+        scores[score_key] = max(0.0, min(100.0, value))
 
-    # Build citations dictionary: gather references for each receptor used.
-    citations: Dict[str, list[str]] = {}
-    for rec_name in inp.receptors.keys():
+    citations: Dict[str, List[Citation]] = {}
+    for rec_name in inp.receptors:
         canon = canonical_receptor_name(rec_name)
         if canon in refs:
             citations[canon] = refs[canon]


### PR DESCRIPTION
## Summary
- replace the simulation output citation field with a dedicated Citation model
- normalize references from refs.json into Citation objects when building responses
- ensure the /simulate endpoint returns structured citation metadata for the frontend

## Testing
- python -m compileall backend
- curl -s http://127.0.0.1:8000/simulate -X POST -H 'Content-Type: application/json' -d '{"receptors":{"5HT2C":{"occ":0.7,"mech":"antagonist"},"5HT1B":{"occ":0.5,"mech":"agonist"}},"adhd":true,"gut_bias":false,"acute_1a":false,"pvt_weight":0.5}'

------
https://chatgpt.com/codex/tasks/task_e_68ce264882088329a1f60ea07ee061ff