### PR TITLE
Normalize receptor references

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-e"""
+"""
 FastAPI backend for the neuropharm simulation lab.
 
 This service exposes a `/simulate` endpoint that accepts a JSON
@@ -23,6 +23,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import numpy as np
 import os
 import json
+import re
 
 from .engine.receptors import get_receptor_weights, get_mechanism_factor, RECEPTORS
 
@@ -105,8 +106,8 @@ def read_root():
 def health():
     return {"status": "ok", "version": "2025.09.05"}
 
-  @app.post("/simulate", response_model=SimulationOutput)
-        tdef simulate(inp: SimulationInput) -> SimulationOutput:
+@app.post("/simulate", response_model=SimulationOutput)
+def simulate(inp: SimulationInput) -> SimulationOutput:
     """Run a single simulation with the provided input.
 
     This function currently implements a highly simplified scoring
@@ -114,8 +115,7 @@ def health():
     5‑HT1B occupancy, modulates it with ADHD state and gut-bias flags,
     and then maps the result into overall "Drive" and "Apathy" scores.
 
-  
-Parameters
+    Parameters
     ----------
     inp : SimulationInput
         The payload specifying receptor occupancies and modifiers.
@@ -127,32 +127,62 @@ Parameters
         and citations underpinning the mechanisms used.
     """
 
-    # ---------------------------------------------------------------------
+    # ------------------------------------------------------------------
     # Helper functions
     #
-    # To support various input naming conventions (e.g. "5HT2C" vs
-    # "5-HT2C"), normalise receptor names by inserting a dash after the
-    # "5" when missing.  This helper returns the canonical key used in
-    # the RECEPTORS mapping.
+    # Canonical receptor names follow the backend convention of
+    # upper-case identifiers with a dashed 5-HT prefix for serotonin
+    # receptors (e.g. "5-HT2C").  This helper folds common variations
+    # such as "5HT2C" or "5_ht2c" into that canonical form.
     def canonical_receptor_name(name: str) -> str:
-        if name in RECEPTORS:
-            return name
-        # Normalise names like "5HT2C" → "5-HT2C" and "5ht1a" → "5-HT1A"
-        name_upper = name.upper().replace("HT", "-HT")
-        return name_upper
+        cleaned = re.sub(r"[\s_]+", "", name).upper()
+        if cleaned in RECEPTORS:
+            return cleaned
+        canonical = re.sub(r"^5[^A-Z0-9]*HT", "5-HT", cleaned)
+        if canonical in RECEPTORS:
+            return canonical
+        return canonical
 
-    # Load receptor citations from refs.json.  This file should map
-    # canonical receptor names to lists of PubMed IDs or DOIs.
+    def normalise_refs(raw_refs: Dict[str, list]) -> Dict[str, list[str]]:
+        """Return a refs mapping keyed by canonical receptor names."""
+
+        normalised: Dict[str, list[str]] = {}
+        for raw_name, entries in raw_refs.items():
+            canon_name = canonical_receptor_name(raw_name)
+            if not canon_name:
+                continue
+            existing_entries = normalised.setdefault(canon_name, [])
+            seen = set(existing_entries)
+            for entry in entries:
+                if isinstance(entry, str):
+                    citation = entry
+                elif isinstance(entry, dict):
+                    parts = []
+                    pmid = entry.get("pmid")
+                    doi = entry.get("doi")
+                    title = entry.get("title")
+                    if pmid:
+                        parts.append(f"PMID:{pmid}")
+                    if doi:
+                        parts.append(f"DOI:{doi}")
+                    if title:
+                        parts.append(title)
+                    citation = " | ".join(parts) if parts else json.dumps(entry, sort_keys=True)
+                else:
+                    citation = str(entry)
+                if citation not in seen:
+                    existing_entries.append(citation)
+                    seen.add(citation)
+        return normalised
+
+    # Load receptor citations from refs.json.  This file maps canonical
+    # receptor names to lists of PubMed IDs or DOIs.
     try:
-        with open(
-            __import__("os").path.join(
-                __import__("os").path.dirname(__file__), "refs.json"
-            ),
-            "r",
-        ) as f:
-            refs = json.load(f)
+        with open(os.path.join(os.path.dirname(__file__), "refs.json"), "r") as f:
+            refs_raw = json.load(f)
     except FileNotFoundError:
-        refs = {}
+        refs_raw = {}
+    refs = normalise_refs(refs_raw)
 
     # Initialise metric contributions.  Baseline of 50 for each metric.
     metrics = [

--- a/backend/refs.json
+++ b/backend/refs.json
@@ -1,40 +1,40 @@
 {
-  "5HT2C": [
+  "5-HT2C": [
     {
       "title": "5-HT2C receptor antagonists reverse SSRI-induced apathy",
       "pmid": "33678231",
       "doi": "10.1016/j.neuropharm.2021.108277"
     }
   ],
-  "5HT1B": [
+  "5-HT1B": [
     {
       "title": "Serotonin 5-HT1B heteroreceptors modulate reward learning",
       "pmid": "31469733",
       "doi": "10.1523/JNEUROSCI.1751-19.2019"
     }
   ],
-  "5HT2A": [
+  "5-HT2A": [
     {
       "title": "Cortical 5‑HT2A receptors regulate glutamatergic output and cognitive flexibility",
       "pmid": "26223110",
       "doi": "10.1016/j.neuron.2015.07.006"
     }
   ],
-  "5HT3": [
+  "5-HT3": [
     {
       "title": "5-HT3 receptor activation on GABA interneurons shapes cortical excitation",
       "pmid": "30544333",
       "doi": "10.1016/j.biopsych.2018.11.015"
     }
   ],
-  "5HT7": [
+  "5-HT7": [
     {
       "title": "Antagonism of 5-HT7 receptors produces antidepressant-like effects and promotes cognitive flexibility",
       "pmid": "20211209",
       "doi": "10.1016/j.psyneuen.2020.104672"
     }
   ],
-  "5HT1A": [
+  "5-HT1A": [
     {
       "title": "Partial agonism at 5-HT1A receptors normalizes HPA axis and improves motivation",
       "pmid": "30658801",


### PR DESCRIPTION
## Summary
- add a canonical receptor name helper that normalises common serotonin aliases to the dashed form used by the backend
- normalise reference metadata by canonical key when loading, collapsing duplicate entries and formatting them as citation strings
- update `refs.json` to use the canonical dashed keys so `/simulate` returns citations for inputs such as `5HT2C`

## Testing
- curl -s -X POST http://127.0.0.1:8000/simulate -H 'Content-Type: application/json' -d '{"receptors": {"5HT2C": {"occ": 0.6, "mech": "agonist"}}, "acute_1a": false, "adhd": false, "gut_bias": false, "pvt_weight": 0.5}' | jq


------
https://chatgpt.com/codex/tasks/task_e_68ce265391148329817e27b68be1ba71