### PR TITLE
Normalize receptor citations and naming

### DIFF
--- a/backend/refs.json
+++ b/backend/refs.json
@@ -1,40 +1,40 @@
 {
-  "5HT2C": [
+  "5-HT2C": [
     {
       "title": "5-HT2C receptor antagonists reverse SSRI-induced apathy",
       "pmid": "33678231",
       "doi": "10.1016/j.neuropharm.2021.108277"
     }
   ],
-  "5HT1B": [
+  "5-HT1B": [
     {
       "title": "Serotonin 5-HT1B heteroreceptors modulate reward learning",
       "pmid": "31469733",
       "doi": "10.1523/JNEUROSCI.1751-19.2019"
     }
   ],
-  "5HT2A": [
+  "5-HT2A": [
     {
       "title": "Cortical 5‑HT2A receptors regulate glutamatergic output and cognitive flexibility",
       "pmid": "26223110",
       "doi": "10.1016/j.neuron.2015.07.006"
     }
   ],
-  "5HT3": [
+  "5-HT3": [
     {
       "title": "5-HT3 receptor activation on GABA interneurons shapes cortical excitation",
       "pmid": "30544333",
       "doi": "10.1016/j.biopsych.2018.11.015"
     }
   ],
-  "5HT7": [
+  "5-HT7": [
     {
       "title": "Antagonism of 5-HT7 receptors produces antidepressant-like effects and promotes cognitive flexibility",
       "pmid": "20211209",
       "doi": "10.1016/j.psyneuen.2020.104672"
     }
   ],
-  "5HT1A": [
+  "5-HT1A": [
     {
       "title": "Partial agonism at 5-HT1A receptors normalizes HPA axis and improves motivation",
       "pmid": "30658801",


### PR DESCRIPTION
## Summary
- add a Citation model and normalise receptor identifiers before loading references so every receptor uses the same canonical form
- update refs.json to use the canonical 5-HTn keys and return structured citation metadata alongside simulation results
- expand receptor-name canonicalisation to accept varied spellings and keep /simulate callable despite inconsistent input names

## Testing
- python -m compileall backend
- python - <<'PY'
from backend.main import simulate, SimulationInput, ReceptorSpec

inp = SimulationInput(
    receptors={
        "5HT2C": ReceptorSpec(occ=0.4, mech="antagonist"),
        "5-HT1A": ReceptorSpec(occ=0.7, mech="agonist"),
    }
)

result = simulate(inp)
print(result.citations)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ce266126c88329a4d90a1db504b1c5