### PR TITLE
Improve citation payload construction for /simulate

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-e"""
+"""
 FastAPI backend for the neuropharm simulation lab.
 
 This service exposes a `/simulate` endpoint that accepts a JSON
@@ -14,13 +14,12 @@ brain regions.
 The API also exposes a root `/` endpoint for a basic health check.
 """
 
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
-from typing import Dict, Any
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+from typing import Dict, Any, Iterable, List, Optional
 from fastapi.middleware.cors import CORSMiddleware
 
 
-import numpy as np
 import os
 import json
 
@@ -58,26 +57,118 @@ class SimulationInput(BaseModel):
     pvt_weight: float = 0.5
 
 
+class Citation(BaseModel):
+    """Reference supporting a receptor mechanism."""
+
+    title: str
+    pmid: Optional[str] = None
+    doi: Optional[str] = None
+
+
 class SimulationOutput(BaseModel):
     """Return format from the simulation engine.
 
     `scores` contains high‑level behavioural metrics normalised to 0–100.
     `details` includes intermediate values (e.g. computed dopamine phasic
     drive) that may be useful for debugging or future UI visualisations.
-    `citations` returns a list of PubMed IDs and/or DOIs supporting the
-    mechanisms involved in generating the result.
+    `citations` returns structured references supporting the mechanisms
+    involved in generating the result.
     """
+
     scores: Dict[str, float]
     details: Dict[str, Any]
-    citations: Dict[str, list[str]]
+    citations: Dict[str, List[Citation]] = Field(default_factory=dict)
+
+
+def canonical_receptor_name(name: str) -> str:
+    """Normalise a receptor name to the canonical key used by the engine."""
+
+    stripped = name.strip()
+    if not stripped:
+        return stripped
+
+    normalised = stripped.upper().replace(" ", "").replace("_", "-")
+
+    if normalised.startswith("5HT"):
+        suffix = normalised[3:].lstrip("-")
+        return f"5-HT{suffix}"
+
+    if normalised.startswith("5-HT"):
+        suffix = normalised[4:].lstrip("-")
+        return f"5-HT{suffix}"
+
+    return normalised
+
+
+def load_references() -> Dict[str, List[Citation]]:
+    """Load structured receptor citations from ``refs.json`` if present."""
+
+    refs_path = os.path.join(os.path.dirname(__file__), "refs.json")
+    try:
+        with open(refs_path, "r", encoding="utf-8") as f:
+            refs_data = json.load(f)
+    except FileNotFoundError:
+        return {}
+
+    references: Dict[str, List[Citation]] = {}
+    for raw_name, entries in refs_data.items():
+        canon_name = canonical_receptor_name(raw_name)
+        if not canon_name:
+            continue
+
+        raw_list = entries if isinstance(entries, list) else [entries]
+        parsed_entries: List[Citation] = []
+        for entry in raw_list:
+            if isinstance(entry, dict):
+                parsed_entries.append(Citation(**entry))
+            elif isinstance(entry, str):
+                parsed_entries.append(Citation(title=entry))
+        if parsed_entries:
+            references.setdefault(canon_name, []).extend(parsed_entries)
+    return references
+
+
+REFERENCES: Dict[str, List[Citation]] = load_references()
+
+
+def clone_citation(ref: Citation) -> Citation:
+    """Return a fresh ``Citation`` instance compatible with Pydantic v1/v2."""
+
+    if hasattr(ref, "model_dump"):
+        data = ref.model_dump()
+    else:  # pragma: no cover - exercised when running under Pydantic v1
+        data = ref.dict()
+    return Citation(**data)
+
+
+def build_citation_payload(receptor_names: Iterable[str]) -> Dict[str, List[Citation]]:
+    """Construct cloned citation entries for the requested receptors."""
+
+    payload: Dict[str, List[Citation]] = {}
+    for name in receptor_names:
+        canon = canonical_receptor_name(name)
+        if not canon:
+            continue
+        refs = REFERENCES.get(canon)
+        if not refs:
+            continue
+        payload[canon] = [clone_citation(ref) for ref in refs]
+    return payload
 
 
 # -----------------------------------------------------------------------------
 # Application
 # -----------------------------------------------------------------------------
 
-app = FastAPI(title="Neuropharm Simulation API",
-              description=("Simulate serotonergic, dopaminergic and other\n                           neurotransmitter systems under a variety of\n                           receptor manipulations.  See the README for\n                           details on the expected payload format."))
+app = FastAPI(
+    title="Neuropharm Simulation API",
+    description=(
+        "Simulate serotonergic, dopaminergic and other\n"
+        "neurotransmitter systems under a variety of\n"
+        "receptor manipulations.  See the README for\n"
+        "details on the expected payload format."
+    ),
+)
 
 # Configure CORS
 origins = os.environ.get("CORS_ORIGINS", "https://darkfrostx-cmd.github.io").split(",")
@@ -105,56 +196,11 @@ def read_root():
 def health():
     return {"status": "ok", "version": "2025.09.05"}
 
-  @app.post("/simulate", response_model=SimulationOutput)
-        tdef simulate(inp: SimulationInput) -> SimulationOutput:
-    """Run a single simulation with the provided input.
 
-    This function currently implements a highly simplified scoring
-    algorithm. It computes phasic dopamine drive based on 5‑HT2C and
-    5‑HT1B occupancy, modulates it with ADHD state and gut-bias flags,
-    and then maps the result into overall "Drive" and "Apathy" scores.
+@app.post("/simulate", response_model=SimulationOutput)
+def simulate(inp: SimulationInput) -> SimulationOutput:
+    """Run a single simulation with the provided input payload."""
 
-  
-Parameters
-    ----------
-    inp : SimulationInput
-        The payload specifying receptor occupancies and modifiers.
-
-    Returns
-    -------
-    SimulationOutput
-        A dictionary containing high‑level scores, intermediate details
-        and citations underpinning the mechanisms used.
-    """
-
-    # ---------------------------------------------------------------------
-    # Helper functions
-    #
-    # To support various input naming conventions (e.g. "5HT2C" vs
-    # "5-HT2C"), normalise receptor names by inserting a dash after the
-    # "5" when missing.  This helper returns the canonical key used in
-    # the RECEPTORS mapping.
-    def canonical_receptor_name(name: str) -> str:
-        if name in RECEPTORS:
-            return name
-        # Normalise names like "5HT2C" → "5-HT2C" and "5ht1a" → "5-HT1A"
-        name_upper = name.upper().replace("HT", "-HT")
-        return name_upper
-
-    # Load receptor citations from refs.json.  This file should map
-    # canonical receptor names to lists of PubMed IDs or DOIs.
-    try:
-        with open(
-            __import__("os").path.join(
-                __import__("os").path.dirname(__file__), "refs.json"
-            ),
-            "r",
-        ) as f:
-            refs = json.load(f)
-    except FileNotFoundError:
-        refs = {}
-
-    # Initialise metric contributions.  Baseline of 50 for each metric.
     metrics = [
         "drive",
         "apathy",
@@ -164,68 +210,53 @@ Parameters
         "sleep_quality",
     ]
     contrib: Dict[str, float] = {m: 0.0 for m in metrics}
+    citation_targets = set()
 
-    # Accumulate contributions from each receptor in the input.  For
-    # unknown receptors, silently ignore.  Mechanism factor scales the
-    # per‑unit weight; occupancy scales the contribution.
     for rec_name, spec in inp.receptors.items():
         canon = canonical_receptor_name(rec_name)
+        if not canon:
+            continue
+        citation_targets.add(canon)
         if canon not in RECEPTORS:
             continue
         weights = get_receptor_weights(canon)
         factor = get_mechanism_factor(spec.mech)
-        for m, w in weights.items():
-            contrib[m] += w * spec.occ * factor
+        for metric, weight in weights.items():
+            contrib[metric] += weight * spec.occ * factor
 
-    # Apply phenotype modifiers.  ADHD reduces baseline tone for drive
-    # and motivation; gut_bias attenuates negative contributions (makes
-    # apathy less severe and drive more preserved); acute_1a lowers
-    # overall serotonergic effect (scale contributions down).
     if inp.adhd:
         contrib["drive"] -= 0.3
         contrib["motivation"] -= 0.2
     if inp.gut_bias:
-        for m in metrics:
-            # If contribution is negative, reduce its magnitude by 10%
-            if contrib[m] < 0:
-                contrib[m] *= 0.9
+        for metric in metrics:
+            if contrib[metric] < 0:
+                contrib[metric] *= 0.9
     if inp.acute_1a:
-        for m in metrics:
-            contrib[m] *= 0.75
-    # PVT gating weight scales contributions from 5-HT1B (if present);
-    # approximate by scaling global contributions by (1 - pvt_weight*0.2)
-    contrib_scale = 1.0 - (inp.pvt_weight * 0.2)
-    for m in metrics:
-        contrib[m] *= contrib_scale
+        for metric in metrics:
+            contrib[metric] *= 0.75
 
-    # Convert contributions to scores.  Baseline is 50; each unit of
-    # contribution moves the score by 20 points.  Clamp between 0 and
-    # 100.  Note: for apathy, higher contribution increases apathy; for
-    # other metrics, contributions add directly.
+    contrib_scale = 1.0 - (inp.pvt_weight * 0.2)
+    for metric in metrics:
+        contrib[metric] *= contrib_scale
+
     scores: Dict[str, float] = {}
-    for m in metrics:
+    for metric in metrics:
         base = 50.0
-        change = 20.0 * contrib[m]
-        val = base + change
-        # Invert apathy into ApathyBlunting (higher apathy = lower score)
-        if m == "apathy":
-            val = 100.0 - val
-        scores_name = {
+        change = 20.0 * contrib[metric]
+        value = base + change
+        if metric == "apathy":
+            value = 100.0 - value
+        score_name = {
             "drive": "DriveInvigoration",
             "apathy": "ApathyBlunting",
             "motivation": "Motivation",
             "cognitive_flexibility": "CognitiveFlexibility",
             "anxiety": "Anxiety",
             "sleep_quality": "SleepQuality",
-        }[m]
-        scores[scores_name] = max(0.0, min(100.0, val))
+        }[metric]
+        scores[score_name] = max(0.0, min(100.0, value))
 
-    # Build citations dictionary: gather references for each receptor used.
-    citations: Dict[str, list[str]] = {}
-    for rec_name in inp.receptors.keys():
-        canon = canonical_receptor_name(rec_name)
-        if canon in refs:
-            citations[canon] = refs[canon]
+    citations = build_citation_payload(citation_targets or inp.receptors.keys())
 
     details = {
         "raw_contributions": contrib,


### PR DESCRIPTION
## Summary
- add a default factory for SimulationOutput.citations so responses always provide a dictionary payload
- harden reference loading by normalising keys, tolerating singleton entries, and skipping empty names
- centralise citation cloning in build_citation_payload and reuse it in /simulate to return canonicalised citation data
- add a clone_citation helper so citation cloning works on both Pydantic v1 and v2 runtimes

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ce2caa6dec832987a1191b4b251015