### PR TITLE
Align 5-HT receptor reference keys with canonical names

### DIFF
--- a/backend/refs.json
+++ b/backend/refs.json
@@ -1,40 +1,40 @@
 {
-  "5HT2C": [
+  "5-HT2C": [
     {
       "title": "5-HT2C receptor antagonists reverse SSRI-induced apathy",
       "pmid": "33678231",
       "doi": "10.1016/j.neuropharm.2021.108277"
     }
   ],
-  "5HT1B": [
+  "5-HT1B": [
     {
       "title": "Serotonin 5-HT1B heteroreceptors modulate reward learning",
       "pmid": "31469733",
       "doi": "10.1523/JNEUROSCI.1751-19.2019"
     }
   ],
-  "5HT2A": [
+  "5-HT2A": [
     {
       "title": "Cortical 5‑HT2A receptors regulate glutamatergic output and cognitive flexibility",
       "pmid": "26223110",
       "doi": "10.1016/j.neuron.2015.07.006"
     }
   ],
-  "5HT3": [
+  "5-HT3": [
     {
       "title": "5-HT3 receptor activation on GABA interneurons shapes cortical excitation",
       "pmid": "30544333",
       "doi": "10.1016/j.biopsych.2018.11.015"
     }
   ],
-  "5HT7": [
+  "5-HT7": [
     {
       "title": "Antagonism of 5-HT7 receptors produces antidepressant-like effects and promotes cognitive flexibility",
       "pmid": "20211209",
       "doi": "10.1016/j.psyneuen.2020.104672"
     }
   ],
-  "5HT1A": [
+  "5-HT1A": [
     {
       "title": "Partial agonism at 5-HT1A receptors normalizes HPA axis and improves motivation",
       "pmid": "30658801",


### PR DESCRIPTION
## Summary
- rename 5-HT receptor reference keys in `backend/refs.json` to match the canonical hyphenated names used by the simulation engine
- ensure citation lookups succeed for serotonergic receptors by aligning reference data with canonical keys

## Testing
- `python - <<'PY'
import json
from pathlib import Path
from backend.engine.receptors import RECEPTORS

def canonical_receptor_name(name: str) -> str:
    if name in RECEPTORS:
        return name
    return name.upper().replace('HT', '-HT')

refs = json.loads(Path('backend/refs.json').read_text())
input_receptors = {
    '5HT2C': {'occ': 0.6, 'mech': 'antagonist'},
    '5-HT1A': {'occ': 0.5, 'mech': 'agonist'},
}
citations = {}
for rec_name in input_receptors:
    canon = canonical_receptor_name(rec_name)
    if canon in refs:
        citations[canon] = refs[canon]

print(citations)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ce2cadd1e88329b062b25a3886e2c1