### PR TITLE
Add structured citation model to simulation output

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -58,6 +58,14 @@ class SimulationInput(BaseModel):
     pvt_weight: float = 0.5
 
 
+class Citation(BaseModel):
+    """Reference supporting a mechanism or receptor effect."""
+
+    title: str
+    pmid: str
+    doi: str
+
+
 class SimulationOutput(BaseModel):
     """Return format from the simulation engine.
 
@@ -69,7 +77,7 @@ class SimulationOutput(BaseModel):
     """
     scores: Dict[str, float]
     details: Dict[str, Any]
-    citations: Dict[str, list[str]]
+    citations: Dict[str, list[Citation]]
 
 
 # -----------------------------------------------------------------------------
@@ -221,11 +229,11 @@ Parameters
         scores[scores_name] = max(0.0, min(100.0, val))
 
     # Build citations dictionary: gather references for each receptor used.
-    citations: Dict[str, list[str]] = {}
+    citations: Dict[str, list[Citation]] = {}
     for rec_name in inp.receptors.keys():
         canon = canonical_receptor_name(rec_name)
         if canon in refs:
-            citations[canon] = refs[canon]
+            citations[canon] = [Citation(**ref) for ref in refs[canon]]
 
     details = {
         "raw_contributions": contrib,


### PR DESCRIPTION
## Summary
- add a dedicated Citation model and update the simulation response schema to use it
- populate the citations dictionary with structured entries that include title, pmid, and doi

## Testing
- python - <<'PY'
from fastapi.testclient import TestClient
from backend.main import app

client = TestClient(app)

payload = {
    "receptors": {
        "5-HT2C": {"occ": 0.7, "mech": "antagonist"},
        "5-HT1B": {"occ": 0.5, "mech": "agonist"}
    },
    "acute_1a": False,
    "adhd": False,
    "gut_bias": False,
    "pvt_weight": 0.5
}

response = client.post("/simulate", json=payload)
print(response.status_code)
print(response.json()["citations"])
PY

------
https://chatgpt.com/codex/tasks/task_e_68ce4ea1ad74832999e292aca233f5d0