### PR TITLE
Streamline backend and add guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Guidelines
+
+These instructions cover the entire repository.
+
+## Required checks
+- Run `python -m compileall backend/main.py` before submitting any changes that touch the backend.
+
+## Backend expectations
+- Keep receptor-normalisation logic in `backend/main.py` reusable; prefer top-level helpers rather than nesting new functions inside route handlers.
+- Preserve the `ReceptorSpec` validation guardrails (occupancy range and allowed mechanisms). If you need different behaviour, update the validator rather than bypassing it.
+
+## Documentation
+- Update the README whenever you change how someone runs the project (desktop or mobile instructions must stay accurate and easy to follow).

--- a/README.md
+++ b/README.md
@@ -41,46 +41,73 @@ neuropharm-sim-lab/
 └── README.md
 ```
 
-## Running locally
+## Quick start for everyone
 
-1. **Clone this repository** and navigate into it:
+The project ships as two parts: a Python API and a static web page. You
+can run both on a laptop/desktop and view the UI either on that machine
+or on a phone/tablet that is on the same Wi‑Fi network.
+
+### A. Desktop or laptop setup (Windows, macOS, Linux)
+
+1. **Install Python 3.9 or newer.**
+   * Windows/macOS: download from [python.org](https://www.python.org/downloads/).
+   * Linux: use your package manager (`sudo apt install python3 python3-pip`).
+
+2. **Download the code.** Either clone via Git or grab the ZIP.
 
    ```bash
    git clone https://github.com/your-user/neuropharm-sim-lab.git
    cd neuropharm-sim-lab
    ```
 
-2. **Install backend dependencies** (requires Python ≥3.9):
+   _No Git?_
+   * Click the green **Code** button on GitHub → **Download ZIP**.
+   * Extract it and open a terminal inside the new folder.
+
+3. **Install the backend dependencies.**
 
    ```bash
    cd backend
    pip install -r requirements.txt
    ```
 
-3. **Start the API** with Uvicorn:
+4. **Start the API server.**
 
    ```bash
    uvicorn main:app --reload
    ```
 
-   By default the API runs on `http://127.0.0.1:8000`.  You can browse
-   auto‑generated Swagger documentation at `http://127.0.0.1:8000/docs`.
+   Leave this terminal open. The API runs at `http://127.0.0.1:8000` and
+   exposes live docs at `http://127.0.0.1:8000/docs`.
 
-4. **Serve the frontend**.  The simplest way is to run a tiny HTTP server
-   from the project root.  Python provides one out of the box:
+5. **Open a second terminal for the frontend.**
 
    ```bash
-   # from the project root
+   cd ..  # back to the project root
    python -m http.server 8080
    ```
 
-   Then navigate to `http://localhost:8080/frontend/index.html` in your browser.
+6. **Visit the app.**
+   * On the same computer: open `http://localhost:8080/frontend/index.html`.
+   * Adjust sliders/toggles, then press **Run simulation** to view scores and citations.
 
-   The page will allow you to move sliders and toggles to set receptor
-   occupancy and mechanisms, choose phenotypic modifiers (ADHD, gut
-   bias, acute 5‑HT1A modulation and PVT weighting) and click **Run
-   simulation** to fetch results from the backend.  A bar chart will
-   display the synthetic scores and a list of citations will appear below.
+### B. Viewing on a phone or tablet (same network)
+
+1. Keep both servers running on your computer (steps A4–A5).
+2. Find your computer’s local IP address:
+   * Windows: run `ipconfig` and look for `IPv4 Address`.
+   * macOS/Linux: run `ip addr` (look for `inet 192.168.x.x`).
+3. On your mobile device, open a browser and visit:
+
+   ```
+   http://<your-computer-ip>:8080/frontend/index.html
+   ```
+
+4. The page will use the same backend through your network. Tap the
+   controls and run simulations as if you were on the desktop.
+
+If it doesn’t load, ensure your firewall allows local connections or use
+the Swagger UI on the computer to verify the API is running.
 
 ## Deploying
 


### PR DESCRIPTION
## Summary
- add repository-wide guardrails for future agents and document required backend checks
- tighten the FastAPI backend by validating receptor inputs, reusing canonical helpers, and caching citation metadata
- refresh the README with desktop and mobile friendly quick-start steps that non-developers can follow

## Testing
- python -m compileall backend/main.py

------
https://chatgpt.com/codex/tasks/task_e_68ce221863388329bd32068e43c1f2c7