### PR TITLE
docs: rewrite local running guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,44 +43,163 @@ neuropharm-sim-lab/
 
 ## Running locally
 
-1. **Clone this repository** and navigate into it:
+Follow this numbered quick-start to see the simulator running on your own
+computer. Each step is written in plain language, and we have included
+call-outs for screenshots you can capture or replace later.
 
-   ```bash
-   git clone https://github.com/your-user/neuropharm-sim-lab.git
-   cd neuropharm-sim-lab
+1. **Prepare your computer**
+
+   * Install [Python 3.9 or newer](https://www.python.org/downloads/) with
+     the "Add Python to PATH" option enabled on Windows.
+   * Install [Git](https://git-scm.com/downloads) so you can download the
+     project (or plan to use the green **Code → Download ZIP** button on
+     GitHub).
+   * Make sure you have a modern web browser such as Chrome, Edge, Firefox,
+     or Safari.
+   * Verify your setup by opening a terminal (Command Prompt on Windows,
+     Terminal on macOS/Linux) and running `python --version`.
+
+   > 📸 **Screenshot placeholder:** Capture the Python installer or the
+   > terminal showing a successful `python --version` check.
+
+2. **Get the project files**
+
+   * Open a terminal and choose a folder where you want the project to
+     live.
+   * Run:
+
+     ```bash
+     git clone https://github.com/your-user/neuropharm-sim-lab.git
+     cd neuropharm-sim-lab
+     ```
+
+     If you downloaded the ZIP instead, unzip it and open the folder in
+     your file explorer.
+
+   > 📸 **Screenshot placeholder:** Show the project folder visible in your
+   > file explorer or terminal after cloning/extracting.
+
+3. **Start the backend (the data engine)**
+
+   * In the terminal, move into the backend folder and install the
+     dependencies:
+
+     ```bash
+     cd backend
+     pip install -r requirements.txt
+     ```
+
+   * Start the FastAPI server:
+
+     ```bash
+     uvicorn main:app --reload
+     ```
+
+     Keep this terminal window open. When you see "Uvicorn running on
+     http://127.0.0.1:8000", the backend is ready. Visit
+     `http://127.0.0.1:8000/docs` in a browser tab if you want to see the
+     interactive API documentation.
+
+   > 📸 **Screenshot placeholder:** Terminal window showing the Uvicorn
+   > startup message.
+
+4. **Point the frontend at your local backend**
+
+   * The frontend defaults to the hosted demo API. Open
+     `frontend/script.js` in any text editor (Notepad, VS Code, TextEdit) and
+     update the top line so it reads:
+
+     ```javascript
+     const API_BASE = 'http://127.0.0.1:8000';
+     ```
+
+   * Save the file. This change tells the web page to talk to the backend
+     you just started.
+
+   > 📸 **Screenshot placeholder:** Text editor showing the updated
+   > `API_BASE` line.
+
+5. **Launch the frontend control panel**
+
+   * Open a second terminal window so the backend can keep running in the
+     first one.
+   * Go to the project’s root folder (the one that contains both `backend`
+     and `frontend`) and run:
+
+     ```bash
+     cd path/to/neuropharm-sim-lab
+     python -m http.server 8080
+     ```
+
+     Leave this window open as well. It shares the frontend files at
+     `http://localhost:8080`.
+   * Open your browser and navigate to
+     `http://localhost:8080/frontend/index.html`. You should now be able to
+     move the sliders, choose modifiers, and click **Run simulation** to see
+     the charts update.
+
+   > 📸 **Screenshot placeholder:** Browser window showing the simulator
+   > page with sliders and the chart.
+
+### Use the simulator from another device on your network
+
+Sometimes you want to explore the simulator from a tablet or phone while the
+servers run on your computer. Follow these steps:
+
+1. **Find your computer’s local IP address.**
+   * Windows: open Command Prompt and run `ipconfig`, then look for the
+     `IPv4 Address` in the section for your active Wi‑Fi/Ethernet adapter.
+   * macOS: open Terminal and run `ipconfig getifaddr en0` (Wi‑Fi) or
+     `ipconfig getifaddr en1` (Ethernet). If those do not work, run
+     `ifconfig` and find the `inet` value under `en0`/`en1`.
+   * Linux: run `hostname -I` or `ip addr` and pick the address that looks
+     like `192.168.x.x` or `10.x.x.x`.
+
+2. **Restart the servers so they listen on your network.**
+   * Stop the backend with `Ctrl+C`, then run:
+
+     ```bash
+     uvicorn main:app --host 0.0.0.0 --port 8000
+     ```
+
+   * Stop the frontend server window with `Ctrl+C`, then run from the project
+     root:
+
+     ```bash
+     python -m http.server 8080 --bind 0.0.0.0
+     ```
+
+3. **Update the frontend API setting.** Edit `frontend/script.js` again so the
+   line reads:
+
+   ```javascript
+   const API_BASE = 'http://<your-ip-address>:8000';
    ```
 
-2. **Install backend dependencies** (requires Python ≥3.9):
+   Replace `<your-ip-address>` with the value you found in step 1 (for example,
+   `http://192.168.1.24:8000`). Save the file.
 
-   ```bash
-   cd backend
-   pip install -r requirements.txt
-   ```
+4. **Connect from the other device.** Make sure the device is on the same
+   Wi‑Fi/network as your computer. Open its browser and visit
+   `http://<your-ip-address>:8080/frontend/index.html`. Mobile browsers may
+   show a warning about an "insecure" connection; choose **Proceed** if
+   prompted.
 
-3. **Start the API** with Uvicorn:
+### Troubleshooting and shutting everything down
 
-   ```bash
-   uvicorn main:app --reload
-   ```
-
-   By default the API runs on `http://127.0.0.1:8000`.  You can browse
-   auto‑generated Swagger documentation at `http://127.0.0.1:8000/docs`.
-
-4. **Serve the frontend**.  The simplest way is to run a tiny HTTP server
-   from the project root.  Python provides one out of the box:
-
-   ```bash
-   # from the project root
-   python -m http.server 8080
-   ```
-
-   Then navigate to `http://localhost:8080/frontend/index.html` in your browser.
-
-   The page will allow you to move sliders and toggles to set receptor
-   occupancy and mechanisms, choose phenotypic modifiers (ADHD, gut
-   bias, acute 5‑HT1A modulation and PVT weighting) and click **Run
-   simulation** to fetch results from the backend.  A bar chart will
-   display the synthetic scores and a list of citations will appear below.
+* **Firewall pop-ups:** Allow Python to communicate on private networks when
+  Windows or macOS asks for permission. If you accidentally blocked it, open
+  your firewall settings and enable inbound connections for Python on ports
+  8000 and 8080.
+* **Port already in use:** If another application is using port 8000 or 8080,
+  pick different numbers (for example 9000 and 9090) when starting Uvicorn and
+  the HTTP server. Update `API_BASE` and the browser URL to match.
+* **Browser cannot reach the backend:** Double-check that both terminal windows
+  are still running and that `API_BASE` matches the server address exactly.
+  Refresh the page after saving any changes.
+* **Stopping the servers:** Press `Ctrl+C` in each terminal window when you are
+  finished. On macOS you can also press `⌘ + .` in the Terminal app. Once the
+  prompts return, both servers are fully stopped.
 
 ## Deploying
 


### PR DESCRIPTION
## Summary
- overhaul the "Running locally" instructions with a plain-language quick-start and screenshot placeholders
- document how to reach the simulator from other devices on the network and how to stop the servers
- add troubleshooting guidance for common setup issues

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce5fa2265c8329adc9b761f8cd1607