### PR TITLE
Add knowledge graph ingestion framework

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,68 @@
+"""Configuration helpers for backend services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from typing import Any, Mapping, MutableMapping, Optional
+
+
+@dataclass(slots=True)
+class GraphConfig:
+    """Configuration for the knowledge graph persistence layer.
+
+    Parameters
+    ----------
+    backend:
+        Name of the backend to use. Supported values are ``"memory"``,
+        ``"neo4j"``, and ``"arangodb"``.
+    uri:
+        Connection URI for the database. For AuraDB this should follow the
+        ``neo4j+s://`` scheme. For ArangoDB use the HTTP endpoint.
+    username / password:
+        Credentials used when establishing a database connection. They are
+        optional so the configuration can also describe anonymous/free-tier
+        setups.
+    database:
+        Optional database name or graph namespace.
+    options:
+        Extra keyword arguments understood by the concrete backend driver.
+    """
+
+    backend: str = "memory"
+    uri: Optional[str] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    database: Optional[str] = None
+    options: MutableMapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Mapping[str, str] | None = None,
+        prefix: str = "GRAPH_",
+    ) -> "GraphConfig":
+        """Create a configuration object from environment variables."""
+
+        env = env or os.environ
+        backend = env.get(f"{prefix}BACKEND", "memory").lower()
+        uri = env.get(f"{prefix}URI")
+        username = env.get(f"{prefix}USERNAME")
+        password = env.get(f"{prefix}PASSWORD")
+        database = env.get(f"{prefix}DATABASE")
+        options: dict[str, Any] = {}
+        for key, value in env.items():
+            if key.startswith(prefix + "OPT_"):
+                option_key = key[len(prefix + "OPT_") :].lower()
+                options[option_key] = value
+        return cls(
+            backend=backend,
+            uri=uri,
+            username=username,
+            password=password,
+            database=database,
+            options=options,
+        )
+
+
+DEFAULT_GRAPH_CONFIG = GraphConfig.from_env()

--- a/backend/graph/__init__.py
+++ b/backend/graph/__init__.py
@@ -1,0 +1,33 @@
+"""Graph knowledge base utilities for the Neuropharm Simulation Lab.
+
+This package bundles Biolink/LinkML-compatible data structures, ingestion
+pipelines for several public knowledge sources, and convenience services for
+serving graph evidence through the API layer.
+"""
+
+from .models import (
+    BiolinkEntity,
+    BiolinkPredicate,
+    Edge,
+    Evidence,
+    Node,
+)
+from .bel import edge_to_bel, node_to_bel
+from .persistence import GraphFragment, GraphGap, GraphStore, InMemoryGraphStore
+from .service import GraphService, EvidenceSummary
+
+__all__ = [
+    "BiolinkEntity",
+    "BiolinkPredicate",
+    "Edge",
+    "Evidence",
+    "GraphFragment",
+    "GraphGap",
+    "GraphService",
+    "EvidenceSummary",
+    "GraphStore",
+    "InMemoryGraphStore",
+    "Node",
+    "edge_to_bel",
+    "node_to_bel",
+]

--- a/backend/graph/bel.py
+++ b/backend/graph/bel.py
@@ -1,0 +1,58 @@
+"""BEL export helpers."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from .models import BiolinkEntity, BiolinkPredicate, Edge, Node
+
+
+PREDICATE_TO_BEL = {
+    BiolinkPredicate.RELATED_TO: "--",
+    BiolinkPredicate.TREATS: "->",
+    BiolinkPredicate.AFFECTS: "=>",
+    BiolinkPredicate.INTERACTS_WITH: "-|",
+    BiolinkPredicate.CONTRIBUTES_TO: "=>",
+    BiolinkPredicate.COEXPRESSION_WITH: "=",
+    BiolinkPredicate.LOCATED_IN: "::",
+    BiolinkPredicate.ASSOCIATED_WITH: "--",
+    BiolinkPredicate.PART_OF: "partOf",
+    BiolinkPredicate.EXPRESSES: "=>",
+}
+
+CATEGORY_TO_BEL = {
+    BiolinkEntity.GENE: "g",
+    BiolinkEntity.CHEMICAL_SUBSTANCE: "a",
+    BiolinkEntity.DISEASE: "path",
+    BiolinkEntity.ANATOMICAL_ENTITY: "bp",
+    BiolinkEntity.BRAIN_REGION: "bp",
+    BiolinkEntity.PHENOTYPIC_FEATURE: "bp",
+    BiolinkEntity.PUBLICATION: "pub",
+    BiolinkEntity.PERSON: "auth",
+    BiolinkEntity.PATHWAY: "path",
+}
+
+
+def node_to_bel(node: Node) -> str:
+    """Render a BEL term for the given node."""
+
+    namespace = CATEGORY_TO_BEL.get(node.category, "a")
+    label = node.name.replace("\"", "'")
+    return f"{namespace}(\"{label}\")"
+
+
+def edge_to_bel(edge: Edge, nodes: Mapping[str, Node]) -> str:
+    """Render a BEL statement for an edge."""
+
+    subject_node = nodes.get(edge.subject)
+    object_node = nodes.get(edge.object)
+    if subject_node is None or object_node is None:
+        raise KeyError("Both subject and object nodes must be provided")
+    predicate = PREDICATE_TO_BEL.get(edge.predicate, "--")
+    evidence_note = ""
+    if edge.evidence:
+        references = [ev.reference for ev in edge.evidence if ev.reference]
+        if references:
+            evidence_note = f" // evidence: {', '.join(references)}"
+    return f"{node_to_bel(subject_node)} {predicate} {node_to_bel(object_node)}{evidence_note}"
+

--- a/backend/graph/ingest_atlases.py
+++ b/backend/graph/ingest_atlases.py
@@ -1,0 +1,122 @@
+"""Allen Brain Atlas and EBRAINS ingestion."""
+
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+try:  # pragma: no cover - optional dependency for live fetches
+    import requests
+except ImportError:  # pragma: no cover
+    requests = None  # type: ignore
+
+from .ingest_base import BaseIngestionJob
+from .models import BiolinkEntity, BiolinkPredicate, Edge, Node
+
+
+class AllenAtlasClient:
+    BASE_URL = "https://api.brain-map.org/api/v2/data/Structure/query.json"
+
+    def __init__(self, session: "requests.Session" | None = None) -> None:
+        if requests is None:
+            raise ImportError("requests is required for AllenAtlasClient")
+        self.session = session or requests.Session()
+
+    def iter_structures(self, limit: int = 100) -> Iterator[dict]:
+        params = {"criteria": "[graph_id$eq1]", "num_rows": limit}
+        response = self.session.get(self.BASE_URL, params=params, timeout=30)
+        response.raise_for_status()
+        structures = response.json().get("msg", [])
+        return iter(structures)
+
+
+class EBrainsAtlasClient:
+    BASE_URL = "https://ebrains-curation.eu/api/atlases/regions"
+
+    def __init__(self, session: "requests.Session" | None = None) -> None:
+        if requests is None:
+            raise ImportError("requests is required for EBrainsAtlasClient")
+        self.session = session or requests.Session()
+
+    def iter_regions(self, limit: int = 100) -> Iterator[dict]:
+        response = self.session.get(self.BASE_URL, timeout=30)
+        response.raise_for_status()
+        results = response.json().get("results", [])
+        return iter(results[:limit])
+
+
+class AllenAtlasIngestion(BaseIngestionJob):
+    name = "allen_atlas"
+    source = "Allen Brain Atlas"
+
+    def __init__(self, client: AllenAtlasClient | None = None) -> None:
+        self.client = client or AllenAtlasClient()
+
+    def fetch(self, limit: int | None = None) -> Iterable[dict]:
+        iterator = self.client.iter_structures(limit=limit or 100)
+        if limit is None:
+            return iterator
+        return (record for i, record in enumerate(iterator) if i < limit)
+
+    def transform(self, record: dict) -> tuple[list[Node], list[Edge]]:
+        node = Node(
+            id=record.get("id", "AllenStructure"),
+            name=record.get("name", "Structure"),
+            category=BiolinkEntity.BRAIN_REGION,
+            provided_by=self.source,
+            attributes={"acronym": record.get("acronym")},
+        )
+        parent_id = record.get("parent_structure_id")
+        edges: list[Edge] = []
+        if parent_id:
+            edges.append(
+                Edge(
+                    subject=node.id,
+                    predicate=BiolinkPredicate.PART_OF,
+                    object=str(parent_id),
+                    evidence=[self.make_evidence(self.source, None, None, relation="hierarchy")],
+                )
+            )
+        return [node], edges
+
+
+class EBrainsAtlasIngestion(BaseIngestionJob):
+    name = "ebrains_atlas"
+    source = "EBRAINS"
+
+    def __init__(self, client: EBrainsAtlasClient | None = None) -> None:
+        self.client = client or EBrainsAtlasClient()
+
+    def fetch(self, limit: int | None = None) -> Iterable[dict]:
+        iterator = self.client.iter_regions(limit=limit or 100)
+        if limit is None:
+            return iterator
+        return (record for i, record in enumerate(iterator) if i < limit)
+
+    def transform(self, record: dict) -> tuple[list[Node], list[Edge]]:
+        node = Node(
+            id=record.get("@id", record.get("identifier", "EBRAINSRegion")),
+            name=record.get("name", "Region"),
+            category=BiolinkEntity.BRAIN_REGION,
+            provided_by=self.source,
+            attributes={"atlas": record.get("atlas")},
+        )
+        coordinates = record.get("hasCoordinates", [])
+        edges: list[Edge] = []
+        for coord in coordinates:
+            edges.append(
+                Edge(
+                    subject=node.id,
+                    predicate=BiolinkPredicate.LOCATED_IN,
+                    object=coord.get("space", "space"),
+                    evidence=[self.make_evidence(self.source, coord.get("@id"), None, type=coord.get("type", "coordinate"))],
+                )
+            )
+        return [node], edges
+
+
+__all__ = [
+    "AllenAtlasClient",
+    "EBrainsAtlasClient",
+    "AllenAtlasIngestion",
+    "EBrainsAtlasIngestion",
+]

--- a/backend/graph/ingest_base.py
+++ b/backend/graph/ingest_base.py
@@ -1,0 +1,54 @@
+"""Common utilities for ingestion jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Protocol
+
+from .models import Edge, Evidence, Node
+from .persistence import GraphStore
+
+
+class SupportsFetch(Protocol):  # pragma: no cover - structural typing helper
+    def __iter__(self) -> Iterable[dict]:
+        ...
+
+
+@dataclass(slots=True)
+class IngestionReport:
+    """Simple summary returned after an ingestion run."""
+
+    name: str
+    records_processed: int = 0
+    nodes_created: int = 0
+    edges_created: int = 0
+
+
+class BaseIngestionJob:
+    """Base class implementing the ingestion workflow."""
+
+    name: str = "base"
+    source: str = ""
+
+    def fetch(self, limit: int | None = None) -> Iterable[dict]:  # pragma: no cover - implemented by subclasses
+        raise NotImplementedError
+
+    def transform(self, record: dict) -> tuple[List[Node], List[Edge]]:  # pragma: no cover - implemented by subclasses
+        raise NotImplementedError
+
+    def run(self, store: GraphStore, limit: int | None = None) -> IngestionReport:
+        report = IngestionReport(name=self.name)
+        for i, record in enumerate(self.fetch(limit=limit)):
+            nodes, edges = self.transform(record)
+            store.upsert_nodes(nodes)
+            store.upsert_edges(edges)
+            report.records_processed += 1
+            report.nodes_created += len(nodes)
+            report.edges_created += len(edges)
+            if limit is not None and i + 1 >= limit:
+                break
+        return report
+
+    @staticmethod
+    def make_evidence(source: str, reference: str | None, confidence: float | None, **annotations: str) -> Evidence:
+        return Evidence(source=source, reference=reference, confidence=confidence, annotations=annotations)

--- a/backend/graph/ingest_chembl.py
+++ b/backend/graph/ingest_chembl.py
@@ -1,0 +1,201 @@
+"""ChEMBL, IUPHAR and BindingDB ingestion jobs."""
+
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+try:  # pragma: no cover - optional dependency for live fetches
+    import requests
+except ImportError:  # pragma: no cover
+    requests = None  # type: ignore
+
+from .ingest_base import BaseIngestionJob
+from .models import BiolinkEntity, BiolinkPredicate, Edge, Node
+
+
+class ChEMBLClient:
+    BASE_URL = "https://www.ebi.ac.uk/chembl/api/data/activity.json"
+
+    def __init__(self, session: "requests.Session" | None = None) -> None:
+        if requests is None:
+            raise ImportError("requests is required for ChEMBLClient")
+        self.session = session or requests.Session()
+
+    def iter_interactions(self, limit: int = 100) -> Iterator[dict]:
+        params = {"limit": limit}
+        response = self.session.get(self.BASE_URL, params=params, timeout=30)
+        response.raise_for_status()
+        return iter(response.json().get("activities", []))
+
+
+class IUPHARClient:
+    BASE_URL = "https://www.guidetopharmacology.org/services/targets"
+
+    def __init__(self, session: "requests.Session" | None = None) -> None:
+        if requests is None:
+            raise ImportError("requests is required for IUPHARClient")
+        self.session = session or requests.Session()
+
+    def iter_targets(self, limit: int = 100) -> Iterator[dict]:
+        response = self.session.get(self.BASE_URL, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        return iter(data[:limit])
+
+
+class BindingDBClient:
+    BASE_URL = "https://www.bindingdb.org/axis2/services/BDBService/getLigandInteractions"
+
+    def __init__(self, session: "requests.Session" | None = None) -> None:
+        if requests is None:
+            raise ImportError("requests is required for BindingDBClient")
+        self.session = session or requests.Session()
+
+    def iter_interactions(self, ligand: str, limit: int = 50) -> Iterator[dict]:
+        params = {"ligand": ligand, "format": "json"}
+        response = self.session.get(self.BASE_URL, params=params, timeout=30)
+        response.raise_for_status()
+        results = response.json() or []
+        return iter(results[:limit])
+
+
+class ChEMBLIngestion(BaseIngestionJob):
+    name = "chembl"
+    source = "ChEMBL"
+
+    def __init__(self, client: ChEMBLClient | None = None) -> None:
+        self.client = client or ChEMBLClient()
+
+    def fetch(self, limit: int | None = None) -> Iterable[dict]:
+        iterator = self.client.iter_interactions(limit=limit or 100)
+        if limit is None:
+            return iterator
+        return (record for i, record in enumerate(iterator) if i < limit)
+
+    def transform(self, record: dict) -> tuple[list[Node], list[Edge]]:
+        nodes: list[Node] = []
+        edges: list[Edge] = []
+        compound_id = record.get("molecule_chembl_id")
+        target_id = record.get("target_chembl_id") or record.get("target", {}).get("target_chembl_id")
+        if not compound_id or not target_id:
+            return nodes, edges
+        compound_node = Node(
+            id=compound_id,
+            name=record.get("molecule_pref_name") or record.get("canonical_smiles", "Compound"),
+            category=BiolinkEntity.CHEMICAL_SUBSTANCE,
+            provided_by=self.source,
+        )
+        target_node = Node(
+            id=target_id,
+            name=record.get("target_pref_name", "Target"),
+            category=BiolinkEntity.GENE,
+            provided_by=self.source,
+        )
+        nodes.extend([compound_node, target_node])
+        edges.append(
+            Edge(
+                subject=compound_node.id,
+                predicate=BiolinkPredicate.INTERACTS_WITH,
+                object=target_node.id,
+                confidence=None,
+                evidence=[
+                    self.make_evidence(
+                        self.source,
+                        record.get("document_chembl_id"),
+                        float(record.get("pchembl_value")) if record.get("pchembl_value") else None,
+                        relation=record.get("standard_relation", "="),
+                    )
+                ],
+            )
+        )
+        return nodes, edges
+
+
+class IUPHARIngestion(BaseIngestionJob):
+    name = "iuphar"
+    source = "IUPHAR"
+
+    def __init__(self, client: IUPHARClient | None = None) -> None:
+        self.client = client or IUPHARClient()
+
+    def fetch(self, limit: int | None = None) -> Iterable[dict]:
+        iterator = self.client.iter_targets(limit=limit or 100)
+        if limit is None:
+            return iterator
+        return (record for i, record in enumerate(iterator) if i < limit)
+
+    def transform(self, record: dict) -> tuple[list[Node], list[Edge]]:
+        node = Node(
+            id=record.get("targetId") or record.get("iupharId", "unknown"),
+            name=record.get("name", "IUPHAR target"),
+            category=BiolinkEntity.GENE,
+            provided_by=self.source,
+            attributes={"family": record.get("family")},
+        )
+        return [node], []
+
+
+class BindingDBIngestion(BaseIngestionJob):
+    name = "bindingdb"
+    source = "BindingDB"
+
+    def __init__(self, client: BindingDBClient | None = None, ligand: str = "CHEMBL25") -> None:
+        self.client = client or BindingDBClient()
+        self.ligand = ligand
+
+    def fetch(self, limit: int | None = None) -> Iterable[dict]:
+        iterator = self.client.iter_interactions(self.ligand, limit=limit or 50)
+        if limit is None:
+            return iterator
+        return (record for i, record in enumerate(iterator) if i < limit)
+
+    def transform(self, record: dict) -> tuple[list[Node], list[Edge]]:
+        nodes: list[Node] = []
+        edges: list[Edge] = []
+        ligand_id = record.get("LigandName") or self.ligand
+        target_id = record.get("TargetAccession") or record.get("UniProt")
+        if not target_id:
+            return nodes, edges
+        ligand_node = Node(
+            id=ligand_id,
+            name=record.get("LigandName", ligand_id),
+            category=BiolinkEntity.CHEMICAL_SUBSTANCE,
+            provided_by=self.source,
+        )
+        target_node = Node(
+            id=target_id,
+            name=record.get("TargetName", target_id),
+            category=BiolinkEntity.GENE,
+            provided_by=self.source,
+        )
+        nodes.extend([ligand_node, target_node])
+        pmid = record.get("PMID")
+        if pmid and not str(pmid).upper().startswith("PMID:"):
+            pmid = f"PMID:{pmid}"
+        edges.append(
+            Edge(
+                subject=ligand_node.id,
+                predicate=BiolinkPredicate.INTERACTS_WITH,
+                object=target_node.id,
+                evidence=[
+                    self.make_evidence(
+                        self.source,
+                        pmid,
+                        None,
+                        measure=str(record.get("Ki")),
+                    )
+                ],
+            )
+        )
+        return nodes, edges
+
+
+__all__ = [
+    "ChEMBLClient",
+    "IUPHARClient",
+    "BindingDBClient",
+    "ChEMBLIngestion",
+    "IUPHARIngestion",
+    "BindingDBIngestion",
+]
+

--- a/backend/graph/ingest_indra.py
+++ b/backend/graph/ingest_indra.py
@@ -1,0 +1,96 @@
+"""INDRA ingestion job."""
+
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+try:  # pragma: no cover - optional dependency for live fetches
+    import requests
+except ImportError:  # pragma: no cover
+    requests = None  # type: ignore
+
+from .ingest_base import BaseIngestionJob
+from .models import BiolinkEntity, BiolinkPredicate, Edge, Node
+
+
+class IndraClient:
+    BASE_URL = "https://db.indra.bio/statements/from_agents"
+
+    def __init__(self, session: "requests.Session" | None = None) -> None:
+        if requests is None:
+            raise ImportError("requests is required for IndraClient")
+        self.session = session or requests.Session()
+
+    def iter_statements(self, agent: str, limit: int = 100) -> Iterator[dict]:
+        params = {"agents": agent, "format": "json", "size": limit}
+        response = self.session.get(self.BASE_URL, params=params, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        return iter(data.get("statements", []))
+
+
+class IndraIngestion(BaseIngestionJob):
+    name = "indra"
+    source = "INDRA"
+
+    def __init__(self, client: IndraClient | None = None, agent: str = "5-HT2A") -> None:
+        self.client = client or IndraClient()
+        self.agent = agent
+
+    def fetch(self, limit: int | None = None) -> Iterable[dict]:
+        iterator = self.client.iter_statements(self.agent, limit=limit or 100)
+        if limit is None:
+            return iterator
+        return (record for i, record in enumerate(iterator) if i < limit)
+
+    def transform(self, record: dict) -> tuple[list[Node], list[Edge]]:
+        nodes: list[Node] = []
+        edges: list[Edge] = []
+        subj = record.get("subject") or {}
+        obj = record.get("object") or {}
+        evidence = record.get("evidence", [])
+        if not subj or not obj:
+            return nodes, edges
+        subject_node = Node(
+            id=subj.get("db_refs", {}).get("HGNC") or subj.get("name", "subject"),
+            name=subj.get("name", "subject"),
+            category=BiolinkEntity.GENE,
+            provided_by=self.source,
+        )
+        object_node = Node(
+            id=obj.get("db_refs", {}).get("HGNC") or obj.get("name", "object"),
+            name=obj.get("name", "object"),
+            category=BiolinkEntity.GENE,
+            provided_by=self.source,
+        )
+        nodes.extend([subject_node, object_node])
+        publications: list[str] = []
+        edge_evidence = []
+        for ev in evidence:
+            pub = ev.get("pmid") or ev.get("text_refs", {}).get("PMID")
+            if pub:
+                publications.append(pub)
+            belief_str = ev.get("annotations", {}).get("belief") if ev.get("annotations") else None
+            confidence = float(belief_str) if belief_str else None
+            edge_evidence.append(
+                self.make_evidence(
+                    self.source,
+                    pub,
+                    confidence,
+                    statement=record.get("type"),
+                )
+            )
+        edges.append(
+            Edge(
+                subject=subject_node.id,
+                predicate=BiolinkPredicate.AFFECTS,
+                object=object_node.id,
+                confidence=record.get("belief"),
+                publications=publications,
+                evidence=edge_evidence,
+            )
+        )
+        return nodes, edges
+
+
+__all__ = ["IndraClient", "IndraIngestion"]

--- a/backend/graph/ingest_openalex.py
+++ b/backend/graph/ingest_openalex.py
@@ -1,0 +1,137 @@
+"""OpenAlex ingestion job."""
+
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+try:  # pragma: no cover - optional dependency for live fetches
+    import requests
+except ImportError:  # pragma: no cover
+    requests = None  # type: ignore
+
+from .ingest_base import BaseIngestionJob
+from .models import BiolinkEntity, BiolinkPredicate, Edge, Node
+
+
+class OpenAlexClient:
+    """Thin wrapper around the OpenAlex API.
+
+    The client is intentionally minimal so it can be replaced with a stub in
+    unit tests.  When running against the live service it honours the
+    recommended polite usage guidelines (per-page limits, user agent headers).
+    """
+
+    BASE_URL = "https://api.openalex.org/works"
+
+    def __init__(self, session: "requests.Session" | None = None, mailto: str | None = None) -> None:
+        if requests is None:
+            raise ImportError("requests is required for OpenAlexClient")
+        self.session = session or requests.Session()
+        self.mailto = mailto
+
+    def iter_works(self, concept: str | None = None, search: str | None = None, per_page: int = 25) -> Iterator[dict]:
+        cursor = "*"
+        headers = {"User-Agent": "neuropharm-sim-lab/ingest"}
+        params = {"per-page": per_page}
+        if self.mailto:
+            params["mailto"] = self.mailto
+        if concept:
+            params["filter"] = f"concepts.id:{concept}"
+        if search:
+            params["search"] = search
+        while True:
+            params["cursor"] = cursor
+            response = self.session.get(self.BASE_URL, params=params, headers=headers, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+            for record in payload.get("results", []):
+                yield record
+            cursor = payload.get("meta", {}).get("next_cursor")
+            if not cursor:
+                break
+
+
+class OpenAlexIngestion(BaseIngestionJob):
+    name = "openalex"
+    source = "OpenAlex"
+
+    def __init__(self, client: OpenAlexClient | None = None, concept: str | None = None, search: str | None = None) -> None:
+        self.client = client or OpenAlexClient()
+        self.concept = concept
+        self.search = search
+
+    def fetch(self, limit: int | None = None) -> Iterable[dict]:
+        iterator = self.client.iter_works(concept=self.concept, search=self.search)
+        if limit is None:
+            return iterator
+
+        def limited() -> Iterator[dict]:
+            for i, record in enumerate(iterator):
+                if i >= limit:
+                    break
+                yield record
+
+        return limited()
+
+    def transform(self, record: dict) -> tuple[list[Node], list[Edge]]:
+        nodes: list[Node] = []
+        edges: list[Edge] = []
+        work_id = record.get("id") or record.get("ids", {}).get("openalex")
+        if not work_id:
+            return nodes, edges
+        work_node = Node(
+            id=work_id,
+            name=record.get("display_name", "Unknown work"),
+            category=BiolinkEntity.PUBLICATION,
+            provided_by=self.source,
+            attributes={
+                "publication_year": record.get("publication_year"),
+                "cited_by_count": record.get("cited_by_count"),
+            },
+        )
+        nodes.append(work_node)
+        for authorship in record.get("authorships", []):
+            author = authorship.get("author", {})
+            author_id = author.get("orcid") or author.get("id")
+            if not author_id:
+                continue
+            author_node = Node(
+                id=author_id,
+                name=author.get("display_name", "Unknown author"),
+                category=BiolinkEntity.PERSON,
+                provided_by=self.source,
+            )
+            nodes.append(author_node)
+            edges.append(
+                Edge(
+                    subject=author_node.id,
+                    predicate=BiolinkPredicate.CONTRIBUTES_TO,
+                    object=work_node.id,
+                    confidence=None,
+                    evidence=[self.make_evidence(self.source, record.get("doi"), None, role=authorship.get("author_position", ""))],
+                )
+            )
+        for concept in record.get("concepts", []):
+            concept_id = concept.get("id") or concept.get("wikidata")
+            if not concept_id:
+                continue
+            concept_node = Node(
+                id=concept_id,
+                name=concept.get("display_name", "Concept"),
+                category=BiolinkEntity.NAMED_THING,
+                provided_by=self.source,
+            )
+            nodes.append(concept_node)
+            edges.append(
+                Edge(
+                    subject=work_node.id,
+                    predicate=BiolinkPredicate.ASSOCIATED_WITH,
+                    object=concept_node.id,
+                    confidence=None,
+                    evidence=[self.make_evidence(self.source, record.get("doi"), None, score=str(concept.get("score", "")))],
+                )
+            )
+        return nodes, edges
+
+
+__all__ = ["OpenAlexClient", "OpenAlexIngestion"]

--- a/backend/graph/models.py
+++ b/backend/graph/models.py
@@ -1,0 +1,210 @@
+"""Core data models for the knowledge graph.
+
+The classes defined here closely follow the LinkML mix-in style used by the
+Biolink model.  They expose ``as_linkml`` helpers so the ingest pipeline can
+serialise nodes/edges in a format that downstream tools (Neo4j, Arango, BEL
+export) understand.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+import re
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional
+
+
+class BiolinkEntity(str, Enum):
+    """Supported Biolink categories."""
+
+    NAMED_THING = "biolink:NamedThing"
+    GENE = "biolink:Gene"
+    CHEMICAL_SUBSTANCE = "biolink:ChemicalSubstance"
+    DISEASE = "biolink:Disease"
+    ANATOMICAL_ENTITY = "biolink:AnatomicalEntity"
+    PHENOTYPIC_FEATURE = "biolink:PhenotypicFeature"
+    PUBLICATION = "biolink:Publication"
+    CELL = "biolink:Cell"
+    BRAIN_REGION = "biolink:BrainRegion"
+    PATHWAY = "biolink:Pathway"
+    PERSON = "biolink:Person"
+
+
+class BiolinkPredicate(str, Enum):
+    """Subset of Biolink predicates used by the ingestion jobs."""
+
+    RELATED_TO = "biolink:related_to"
+    TREATS = "biolink:treats"
+    AFFECTS = "biolink:affects"
+    EXPRESSES = "biolink:expresses"
+    INTERACTS_WITH = "biolink:interacts_with"
+    CONTRIBUTES_TO = "biolink:contributes_to"
+    COEXPRESSION_WITH = "biolink:coexpressed_with"
+    LOCATED_IN = "biolink:located_in"
+    ASSOCIATED_WITH = "biolink:associated_with"
+    PART_OF = "biolink:part_of"
+
+
+PREFIX_PATTERNS: dict[BiolinkEntity, tuple[str, ...]] = {
+    BiolinkEntity.GENE: ("HGNC", "NCBIGene", "ENSEMBL", "ENSG"),
+    BiolinkEntity.CHEMICAL_SUBSTANCE: ("CHEMBL", "DRUGBANK", "PUBCHEM"),
+    BiolinkEntity.DISEASE: ("MONDO", "DOID", "EFO"),
+    BiolinkEntity.ANATOMICAL_ENTITY: ("UBERON", "BIRNLEX", "MBA"),
+    BiolinkEntity.BRAIN_REGION: ("UBERON", "MBA", "EBRAINS"),
+    BiolinkEntity.PHENOTYPIC_FEATURE: ("HP", "MP"),
+    BiolinkEntity.PUBLICATION: ("PMID", "DOI"),
+    BiolinkEntity.PERSON: ("ORCID", "OPENALEX"),
+}
+
+
+@dataclass(slots=True)
+class Evidence:
+    """Evidence supporting an edge."""
+
+    source: str
+    reference: Optional[str] = None
+    confidence: Optional[float] = None
+    uncertainty: Optional[str] = None
+    annotations: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def as_linkml(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "reference": self.reference,
+            "confidence": self.confidence,
+            "uncertainty": self.uncertainty,
+            "annotations": dict(self.annotations),
+        }
+
+
+@dataclass(slots=True)
+class Node:
+    """Representation of a Biolink node."""
+
+    id: str
+    name: str
+    category: BiolinkEntity = BiolinkEntity.NAMED_THING
+    description: Optional[str] = None
+    provided_by: Optional[str] = None
+    synonyms: List[str] = field(default_factory=list)
+    xrefs: List[str] = field(default_factory=list)
+    attributes: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.id = normalize_identifier(self.category, self.id)
+        self.xrefs = [normalize_curie(xref) for xref in self.xrefs]
+
+    def as_linkml(self) -> dict[str, Any]:
+        """Return a LinkML-compatible dict representation."""
+
+        return {
+            "id": self.id,
+            "name": self.name,
+            "category": self.category.value,
+            "description": self.description,
+            "provided_by": self.provided_by,
+            "synonym": list(self.synonyms),
+            "xref": list(self.xrefs),
+            "attributes": dict(self.attributes),
+        }
+
+
+@dataclass(slots=True)
+class Edge:
+    """Representation of a Biolink edge with attached evidence."""
+
+    subject: str
+    predicate: BiolinkPredicate
+    object: str
+    relation: str = "biolink:related_to"
+    knowledge_level: Optional[str] = None
+    confidence: Optional[float] = None
+    publications: List[str] = field(default_factory=list)
+    evidence: List[Evidence] = field(default_factory=list)
+    qualifiers: MutableMapping[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def __post_init__(self) -> None:
+        self.subject = normalize_curie(self.subject)
+        self.object = normalize_curie(self.object)
+        self.publications = [normalize_identifier(BiolinkEntity.PUBLICATION, pub) for pub in self.publications]
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        return (self.subject, self.predicate.value, self.object)
+
+    def as_linkml(self) -> dict[str, Any]:
+        return {
+            "subject": self.subject,
+            "predicate": self.predicate.value,
+            "object": self.object,
+            "relation": self.relation,
+            "knowledge_level": self.knowledge_level,
+            "confidence": self.confidence,
+            "publications": list(self.publications),
+            "evidence": [ev.as_linkml() for ev in self.evidence],
+            "qualifiers": dict(self.qualifiers),
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+def normalize_identifier(category: BiolinkEntity, identifier: str) -> str:
+    """Normalise identifiers into CURIE form."""
+
+    identifier = identifier.strip()
+    if not identifier:
+        raise ValueError("Empty identifier")
+    if ":" in identifier and not identifier.lower().startswith("http"):
+        prefix, local_id = identifier.split(":", 1)
+        prefix = prefix.upper()
+        local_id = local_id.strip()
+        return f"{prefix}:{local_id}"
+    if category in PREFIX_PATTERNS:
+        patterns = PREFIX_PATTERNS[category]
+        for prefix in patterns:
+            if identifier.upper().startswith(prefix.upper() + ":"):
+                return identifier.upper()
+        if category == BiolinkEntity.PUBLICATION and identifier.isdigit():
+            return f"PMID:{identifier}"
+    cleaned = re.sub(r"[^A-Za-z0-9]+", "_", identifier).strip("_")
+    default_prefix = PREFIX_PATTERNS.get(category, ("NEUROPHARM",))[0]
+    return f"{default_prefix}:{cleaned}".upper()
+
+
+def normalize_curie(value: str) -> str:
+    value = value.strip()
+    if not value:
+        raise ValueError("Empty CURIE")
+    if value.lower().startswith("http"):
+        return value
+    if ":" in value:
+        prefix, local_id = value.split(":", 1)
+        return f"{prefix.upper()}:{local_id}"
+    return value.upper()
+
+
+def merge_evidence(existing: Iterable[Evidence], new: Iterable[Evidence]) -> list[Evidence]:
+    """Merge evidence lists, deduplicating by (source, reference)."""
+
+    seen: dict[tuple[str, Optional[str]], Evidence] = {}
+    for evidence in list(existing) + list(new):
+        key = (evidence.source, evidence.reference)
+        if key in seen:
+            base = seen[key]
+            if evidence.confidence is not None:
+                base.confidence = (
+                    evidence.confidence
+                    if base.confidence is None
+                    else max(base.confidence, evidence.confidence)
+                )
+            base.annotations.update(evidence.annotations)
+        else:
+            seen[key] = Evidence(
+                source=evidence.source,
+                reference=evidence.reference,
+                confidence=evidence.confidence,
+                uncertainty=evidence.uncertainty,
+                annotations=dict(evidence.annotations),
+            )
+    return list(seen.values())

--- a/backend/graph/persistence.py
+++ b/backend/graph/persistence.py
@@ -1,0 +1,254 @@
+"""Persistence backends for the knowledge graph."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence
+
+try:  # pragma: no cover - optional dependency
+    from neo4j import GraphDatabase
+except Exception:  # pragma: no cover - optional dependency
+    GraphDatabase = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from arango import ArangoClient
+except Exception:  # pragma: no cover - optional dependency
+    ArangoClient = None  # type: ignore
+
+from .models import BiolinkPredicate, Edge, Evidence, Node, merge_evidence
+
+
+@dataclass(slots=True)
+class GraphFragment:
+    """Subgraph returned by expansion queries."""
+
+    nodes: List[Node]
+    edges: List[Edge]
+
+
+@dataclass(slots=True)
+class GraphGap:
+    """Potential gap in the knowledge graph."""
+
+    subject: str
+    object: str
+    reason: str
+
+
+class GraphStore:
+    """Abstract interface for persisting and querying the knowledge graph."""
+
+    def upsert_nodes(self, nodes: Iterable[Node]) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def upsert_edges(self, edges: Iterable[Edge]) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def get_node(self, node_id: str) -> Node | None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def get_edge(self, subject: str, predicate: str, object_: str) -> Edge | None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def get_edge_evidence(
+        self, subject: str | None = None, predicate: str | None = None, object_: str | None = None
+    ) -> List[Edge]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def neighbors(self, node_id: str, depth: int = 1, limit: int = 25) -> GraphFragment:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def find_gaps(self, focus_nodes: Sequence[str]) -> List[GraphGap]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class InMemoryGraphStore(GraphStore):
+    """Simple in-memory graph store for tests and local development."""
+
+    def __init__(self) -> None:
+        self._nodes: Dict[str, Node] = {}
+        self._edges: Dict[tuple[str, str, str], Edge] = {}
+
+    def upsert_nodes(self, nodes: Iterable[Node]) -> None:
+        for node in nodes:
+            self._nodes[node.id] = node
+
+    def upsert_edges(self, edges: Iterable[Edge]) -> None:
+        for edge in edges:
+            key = edge.key
+            if key in self._edges:
+                existing = self._edges[key]
+                existing.confidence = edge.confidence or existing.confidence
+                existing.publications = sorted(set(existing.publications + edge.publications))
+                existing.evidence = merge_evidence(existing.evidence, edge.evidence)
+                existing.qualifiers.update(edge.qualifiers)
+            else:
+                self._edges[key] = edge
+
+    def get_node(self, node_id: str) -> Node | None:
+        return self._nodes.get(node_id)
+
+    def get_edge(self, subject: str, predicate: str, object_: str) -> Edge | None:
+        return self._edges.get((subject, predicate, object_))
+
+    def get_edge_evidence(
+        self, subject: str | None = None, predicate: str | None = None, object_: str | None = None
+    ) -> List[Edge]:
+        results: List[Edge] = []
+        for (subj, pred, obj), edge in self._edges.items():
+            if subject and subj != subject:
+                continue
+            if predicate and pred != predicate:
+                continue
+            if object_ and obj != object_:
+                continue
+            results.append(edge)
+        return sorted(results, key=lambda e: (e.subject, e.predicate.value, e.object))
+
+    def neighbors(self, node_id: str, depth: int = 1, limit: int = 25) -> GraphFragment:
+        visited = {node_id}
+        frontier = {node_id}
+        nodes: Dict[str, Node] = {}
+        edges: List[Edge] = []
+        for _ in range(depth):
+            next_frontier: set[str] = set()
+            for key, node in self._nodes.items():
+                if key in frontier:
+                    nodes[key] = node
+            for (subj, _, obj), edge in self._edges.items():
+                if subj in frontier or obj in frontier:
+                    edges.append(edge)
+                    if subj not in visited:
+                        next_frontier.add(subj)
+                    if obj not in visited:
+                        next_frontier.add(obj)
+            visited.update(next_frontier)
+            frontier = next_frontier
+            if len(nodes) >= limit:
+                break
+        for key in list(nodes):
+            if len(nodes) >= limit:
+                break
+        return GraphFragment(nodes=list(nodes.values())[:limit], edges=edges[: limit * 2])
+
+    def find_gaps(self, focus_nodes: Sequence[str]) -> List[GraphGap]:
+        gaps: List[GraphGap] = []
+        focus = [node for node in focus_nodes if node in self._nodes]
+        for i, subject in enumerate(focus):
+            for object_ in focus[i + 1 :]:
+                if (subject, BiolinkPredicate.RELATED_TO.value, object_) not in self._edges and (
+                    object_, BiolinkPredicate.RELATED_TO.value, subject
+                ) not in self._edges:
+                    gaps.append(
+                        GraphGap(
+                            subject=subject,
+                            object=object_,
+                            reason="No related_to edge connecting the focus nodes.",
+                        )
+                    )
+        return gaps
+
+
+class Neo4jGraphStore(GraphStore):  # pragma: no cover - requires external service
+    """Neo4j-backed store used for production deployments."""
+
+    def __init__(self, uri: str, username: str | None = None, password: str | None = None) -> None:
+        if GraphDatabase is None:
+            raise ImportError("neo4j driver is not installed")
+        self._driver = GraphDatabase.driver(uri, auth=(username, password) if username else None)
+
+    def close(self) -> None:
+        self._driver.close()
+
+    def upsert_nodes(self, nodes: Iterable[Node]) -> None:
+        cypher = """
+        UNWIND $rows AS row
+        MERGE (n {id: row.id})
+        SET n += row.properties
+        """
+        payload = [
+            {"id": node.id, "properties": {k: v for k, v in node.as_linkml().items() if v is not None}}
+            for node in nodes
+        ]
+        if not payload:
+            return
+        with self._driver.session() as session:
+            session.run(cypher, rows=payload)
+
+    def upsert_edges(self, edges: Iterable[Edge]) -> None:
+        cypher = """
+        UNWIND $rows AS row
+        MATCH (s {id: row.subject})
+        MATCH (o {id: row.object})
+        MERGE (s)-[r:REL {predicate: row.predicate, object: row.object, subject: row.subject}]->(o)
+        SET r += row.properties
+        """
+        payload = [
+            {
+                "subject": edge.subject,
+                "object": edge.object,
+                "predicate": edge.predicate.value,
+                "properties": {k: v for k, v in edge.as_linkml().items() if k not in {"subject", "object", "predicate"}},
+            }
+            for edge in edges
+        ]
+        if not payload:
+            return
+        with self._driver.session() as session:
+            session.run(cypher, rows=payload)
+
+    def get_node(self, node_id: str) -> Node | None:
+        raise NotImplementedError("Direct Neo4j queries are handled by the API layer")
+
+    def get_edge(self, subject: str, predicate: str, object_: str) -> Edge | None:
+        raise NotImplementedError("Direct Neo4j queries are handled by the API layer")
+
+    def get_edge_evidence(self, subject: str | None = None, predicate: str | None = None, object_: str | None = None) -> List[Edge]:
+        raise NotImplementedError("Direct Neo4j queries are handled by the API layer")
+
+    def neighbors(self, node_id: str, depth: int = 1, limit: int = 25) -> GraphFragment:
+        raise NotImplementedError("Direct Neo4j queries are handled by the API layer")
+
+    def find_gaps(self, focus_nodes: Sequence[str]) -> List[GraphGap]:
+        raise NotImplementedError("Direct Neo4j queries are handled by the API layer")
+
+
+class ArangoGraphStore(GraphStore):  # pragma: no cover - requires external service
+    """ArangoDB-backed graph store."""
+
+    def __init__(self, uri: str, username: str | None = None, password: str | None = None, database: str | None = None) -> None:
+        if ArangoClient is None:
+            raise ImportError("python-arango is not installed")
+        self._client = ArangoClient(hosts=uri)
+        self._db = self._client.db(database or "_system", username=username, password=password)
+        self._vertex_collection = self._db.collection("nodes")
+        self._edge_collection = self._db.collection("edges")
+
+    def upsert_nodes(self, nodes: Iterable[Node]) -> None:
+        for node in nodes:
+            self._vertex_collection.insert_or_replace({"_key": node.id, **node.as_linkml()})
+
+    def upsert_edges(self, edges: Iterable[Edge]) -> None:
+        for edge in edges:
+            self._edge_collection.insert_or_replace(
+                {
+                    "_from": f"nodes/{edge.subject}",
+                    "_to": f"nodes/{edge.object}",
+                    **edge.as_linkml(),
+                }
+            )
+
+    def get_node(self, node_id: str) -> Node | None:
+        raise NotImplementedError
+
+    def get_edge(self, subject: str, predicate: str, object_: str) -> Edge | None:
+        raise NotImplementedError
+
+    def get_edge_evidence(self, subject: str | None = None, predicate: str | None = None, object_: str | None = None) -> List[Edge]:
+        raise NotImplementedError
+
+    def neighbors(self, node_id: str, depth: int = 1, limit: int = 25) -> GraphFragment:
+        raise NotImplementedError
+
+    def find_gaps(self, focus_nodes: Sequence[str]) -> List[GraphGap]:
+        raise NotImplementedError

--- a/backend/graph/service.py
+++ b/backend/graph/service.py
@@ -1,0 +1,73 @@
+"""Graph service utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from ..config import DEFAULT_GRAPH_CONFIG, GraphConfig
+from .models import Edge, Evidence, Node
+from .persistence import GraphFragment, GraphGap, GraphStore, InMemoryGraphStore
+
+
+@dataclass(slots=True)
+class EvidenceSummary:
+    """Lightweight structure returned to the API layer."""
+
+    edge: Edge
+    evidence: List[Evidence]
+
+
+class GraphService:
+    """High-level service exposing evidence and graph queries."""
+
+    def __init__(self, store: GraphStore | None = None, config: GraphConfig | None = None) -> None:
+        self.config = config or DEFAULT_GRAPH_CONFIG
+        if store is not None:
+            self.store = store
+        else:
+            self.store = self._create_store(self.config)
+
+    def _create_store(self, config: GraphConfig) -> GraphStore:
+        if config.backend == "memory":
+            return InMemoryGraphStore()
+        if config.backend == "neo4j":  # pragma: no cover - requires driver
+            from .persistence import Neo4jGraphStore
+
+            return Neo4jGraphStore(config.uri or "", config.username, config.password)
+        if config.backend == "arangodb":  # pragma: no cover - requires driver
+            from .persistence import ArangoGraphStore
+
+            return ArangoGraphStore(config.uri or "", config.username, config.password, config.database)
+        raise ValueError(f"Unsupported graph backend: {config.backend}")
+
+    # ------------------------------------------------------------------
+    # Evidence lookup utilities
+    # ------------------------------------------------------------------
+    def get_evidence(
+        self,
+        subject: str | None = None,
+        predicate: str | None = None,
+        object_: str | None = None,
+    ) -> List[EvidenceSummary]:
+        edges = self.store.get_edge_evidence(subject=subject, predicate=predicate, object_=object_)
+        return [EvidenceSummary(edge=edge, evidence=edge.evidence) for edge in edges]
+
+    # ------------------------------------------------------------------
+    # Graph navigation helpers
+    # ------------------------------------------------------------------
+    def expand(self, node_id: str, depth: int = 1, limit: int = 25) -> GraphFragment:
+        return self.store.neighbors(node_id, depth=depth, limit=limit)
+
+    def find_gaps(self, node_ids: Sequence[str]) -> List[GraphGap]:
+        return self.store.find_gaps(node_ids)
+
+    # ------------------------------------------------------------------
+    # Persistence helpers used by ingestion jobs
+    # ------------------------------------------------------------------
+    def persist(self, nodes: Iterable[Node], edges: Iterable[Edge]) -> None:
+        self.store.upsert_nodes(nodes)
+        self.store.upsert_edges(edges)
+
+
+__all__ = ["GraphService", "EvidenceSummary"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.30.6
 numpy>=1.22.0
 scipy>=1.8.0
 pydantic>=2.1.1
+requests>=2.31.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/backend/tests/test_graph_service.py
+++ b/backend/tests/test_graph_service.py
@@ -1,0 +1,57 @@
+from backend.graph.models import (
+    BiolinkEntity,
+    BiolinkPredicate,
+    Edge,
+    Evidence,
+    Node,
+)
+from backend.graph.persistence import GraphGap, InMemoryGraphStore
+from backend.graph.service import GraphService
+
+
+def build_store() -> InMemoryGraphStore:
+    store = InMemoryGraphStore()
+    node_a = Node(id="CHEMBL:25", name="Sertraline", category=BiolinkEntity.CHEMICAL_SUBSTANCE)
+    node_b = Node(id="HGNC:5", name="SLC6A4", category=BiolinkEntity.GENE)
+    node_c = Node(id="HGNC:6", name="HTR2A", category=BiolinkEntity.GENE)
+    store.upsert_nodes([node_a, node_b, node_c])
+    edge_ab = Edge(
+        subject=node_a.id,
+        predicate=BiolinkPredicate.INTERACTS_WITH,
+        object=node_b.id,
+        confidence=0.8,
+        evidence=[Evidence(source="ChEMBL", reference="PMID:1", confidence=0.8)],
+    )
+    edge_bc = Edge(
+        subject=node_b.id,
+        predicate=BiolinkPredicate.RELATED_TO,
+        object=node_c.id,
+        evidence=[Evidence(source="OpenAlex", reference="10.1000/example")],
+    )
+    store.upsert_edges([edge_ab, edge_bc])
+    return store
+
+
+def test_get_evidence_returns_summaries() -> None:
+    store = build_store()
+    service = GraphService(store=store)
+    summaries = service.get_evidence(subject="CHEMBL:25")
+    assert summaries
+    assert summaries[0].evidence[0].source == "ChEMBL"
+
+
+def test_expand_returns_fragment() -> None:
+    store = build_store()
+    service = GraphService(store=store)
+    fragment = service.expand("HGNC:5", depth=1)
+    node_ids = {node.id for node in fragment.nodes}
+    assert "HGNC:5" in node_ids
+    assert any(edge.predicate == BiolinkPredicate.RELATED_TO for edge in fragment.edges)
+
+
+def test_find_gaps_between_focus_nodes() -> None:
+    store = build_store()
+    service = GraphService(store=store)
+    gaps = service.find_gaps(["HGNC:5", "HGNC:6", "CHEMBL:25"])
+    assert isinstance(gaps, list)
+    assert any(isinstance(gap, GraphGap) for gap in gaps)

--- a/backend/tests/test_ingestion.py
+++ b/backend/tests/test_ingestion.py
@@ -1,0 +1,107 @@
+from backend.graph.ingest_openalex import OpenAlexIngestion
+from backend.graph.ingest_chembl import (
+    BindingDBIngestion,
+    ChEMBLIngestion,
+)
+from backend.graph.ingest_indra import IndraIngestion
+from backend.graph.persistence import InMemoryGraphStore
+from backend.graph.models import BiolinkPredicate
+
+
+class StubOpenAlexClient:
+    def iter_works(self, concept=None, search=None, per_page=25):  # noqa: D401 - match interface
+        yield {
+            "id": "https://openalex.org/W1",
+            "display_name": "Serotonin transporters in ADHD",
+            "doi": "10.1000/example",
+            "publication_year": 2024,
+            "cited_by_count": 5,
+            "authorships": [
+                {
+                    "author": {"orcid": "0000-0002-1825-0097", "display_name": "Doe, J."},
+                    "author_position": "first",
+                }
+            ],
+            "concepts": [
+                {"id": "https://openalex.org/C1", "display_name": "Serotonin", "score": 0.9}
+            ],
+        }
+
+
+class StubChEMBLClient:
+    def iter_interactions(self, limit=100):  # noqa: D401
+        yield {
+            "molecule_chembl_id": "CHEMBL25",
+            "molecule_pref_name": "Sertraline",
+            "target_chembl_id": "CHEMBL1957",
+            "target_pref_name": "SLC6A4",
+            "document_chembl_id": "CHEMBL_DOC",
+            "pchembl_value": "7.5",
+            "standard_relation": "=",
+        }
+
+
+class StubBindingDBClient:
+    def iter_interactions(self, ligand, limit=50):  # noqa: D401
+        yield {
+            "LigandName": ligand,
+            "TargetAccession": "P31645",
+            "TargetName": "SLC6A4",
+            "PMID": "12345",
+            "Ki": 5.2,
+        }
+
+
+class StubIndraClient:
+    def iter_statements(self, agent, limit=100):  # noqa: D401
+        yield {
+            "type": "Activation",
+            "belief": 0.73,
+            "subject": {"name": "HTR2A", "db_refs": {"HGNC": "HGNC:5293"}},
+            "object": {"name": "GNAQ", "db_refs": {"HGNC": "HGNC:4381"}},
+            "evidence": [
+                {"pmid": "55555", "annotations": {"belief": 0.73}},
+            ],
+        }
+
+
+def test_openalex_ingestion_creates_publication_and_author():
+    store = InMemoryGraphStore()
+    ingestion = OpenAlexIngestion(client=StubOpenAlexClient())
+    report = ingestion.run(store)
+    assert report.records_processed == 1
+    edges = store.get_edge_evidence()
+    assert any(edge.predicate == BiolinkPredicate.CONTRIBUTES_TO for edge in edges)
+    # ensure DOI preserved in evidence annotations
+    evidence_refs = [ev.reference for edge in edges for ev in edge.evidence if ev.reference]
+    assert "10.1000/example" in evidence_refs
+
+
+def test_chembl_ingestion_interaction():
+    store = InMemoryGraphStore()
+    ingestion = ChEMBLIngestion(client=StubChEMBLClient())
+    ingestion.run(store)
+    edges = store.get_edge_evidence()
+    interaction_edges = [edge for edge in edges if edge.predicate == BiolinkPredicate.INTERACTS_WITH]
+    assert interaction_edges
+    assert interaction_edges[0].evidence[0].annotations["relation"] == "="
+
+
+def test_bindingdb_ingestion_interaction():
+    store = InMemoryGraphStore()
+    ingestion = BindingDBIngestion(client=StubBindingDBClient(), ligand="CHEMBL25")
+    ingestion.run(store)
+    edges = store.get_edge_evidence(predicate=BiolinkPredicate.INTERACTS_WITH.value)
+    assert edges
+    assert edges[0].evidence[0].reference == "PMID:12345"
+
+
+def test_indra_ingestion_affects_relation():
+    store = InMemoryGraphStore()
+    ingestion = IndraIngestion(client=StubIndraClient(), agent="HTR2A")
+    ingestion.run(store)
+    edges = store.get_edge_evidence(predicate=BiolinkPredicate.AFFECTS.value)
+    assert edges
+    edge = edges[0]
+    assert edge.confidence == 0.73
+    assert edge.publications == ["PMID:55555"]


### PR DESCRIPTION
## Summary
- add a backend/graph package with Biolink/LinkML-friendly node, edge, evidence models plus BEL export utilities and persistence backends
- implement ingestion jobs for OpenAlex, INDRA, ChEMBL/IUPHAR/BindingDB, and Allen/EBRAINS atlases along with a graph service facade and configuration helper
- document the new data refresh cadence and free-tier expectations and cover ingestion/graph behaviour with unit tests

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce6a5a52108329ae5efbcd90f59666