### PR TITLE
Add multiscale simulation pipeline and regression tests

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,9 @@ uvicorn[standard]==0.30.6
 numpy>=1.22.0
 scipy>=1.8.0
 pydantic>=2.1.1
+httpx>=0.27
+pysb>=1.15
+tvb-library>=2.8
+
+# External binary dependency (install separately):
+# PK-Sim – available via the Open Systems Pharmacology Suite

--- a/backend/simulation/__init__.py
+++ b/backend/simulation/__init__.py
@@ -1,0 +1,23 @@
+"""Multiscale simulation components.
+
+The :mod:`backend.simulation` package provides lightweight facades around the
+specialised scientific simulators used by the Neuropharm Simulation Lab.  The
+interfaces are deliberately typed and easily mockable so that unit tests can
+exercise the orchestration logic without requiring PySB, The Virtual Brain, or
+PK-Sim binaries at runtime.  Each submodule exposes a ``simulate_*`` function
+that accepts a configuration dataclass and returns a structured result dataclass.
+"""
+
+from .engine import (
+    MultiscaleResult,
+    ReceptorInput,
+    SimulationConfig,
+    run_multiscale_pipeline,
+)
+
+__all__ = [
+    "MultiscaleResult",
+    "ReceptorInput",
+    "SimulationConfig",
+    "run_multiscale_pipeline",
+]

--- a/backend/simulation/circuit.py
+++ b/backend/simulation/circuit.py
@@ -1,0 +1,131 @@
+"""Regional circuit simulations wrapping The Virtual Brain abstractions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Sequence
+
+from .molecular import ExposureMode
+from .pkpd import PKPDResult
+
+
+METRIC_REGION_WEIGHTS: Mapping[str, Mapping[str, float]] = {
+    "drive": {"Striatum": 0.6, "VTA": 0.4},
+    "apathy": {"Striatum": -0.5, "PFC": 0.3},
+    "motivation": {"Striatum": 0.4, "PFC": 0.3, "Hippocampus": 0.3},
+    "cognitive_flexibility": {"PFC": 0.6, "Hippocampus": 0.4},
+    "anxiety": {"Amygdala": 0.6, "PFC": 0.2, "Hippocampus": -0.2},
+    "sleep_quality": {"Thalamus": 0.5, "Hippocampus": 0.3, "PFC": -0.2},
+}
+
+SCORE_NAME_MAP: Mapping[str, str] = {
+    "drive": "DriveInvigoration",
+    "apathy": "ApathyBlunting",
+    "motivation": "Motivation",
+    "cognitive_flexibility": "CognitiveFlexibility",
+    "anxiety": "Anxiety",
+    "sleep_quality": "SleepQuality",
+}
+
+
+@dataclass(frozen=True)
+class CircuitConfig:
+    """Configuration for the TVB-based regional circuit simulation."""
+
+    time: Sequence[float]
+    exposure: ExposureMode
+    region_baseline: Mapping[str, float]
+    region_modulation: Mapping[str, float]
+    connectivity: Mapping[str, Mapping[str, float]]
+    propagate_uncertainty: bool = True
+
+
+@dataclass
+class CircuitResult:
+    """Regional activity traces and behavioural summaries."""
+
+    time: list[float]
+    region_activity: Dict[str, list[float]]
+    metric_traces: Dict[str, list[float]]
+    behavioural_summary: Dict[str, float]
+    uncertainty: Dict[str, float]
+    region_uncertainty: Dict[str, float]
+
+
+def simulate_circuit(config: CircuitConfig, pkpd: PKPDResult) -> CircuitResult:
+    """Simulate mesoscale circuit dynamics using weighted surrogates."""
+
+    time_axis = list(config.time)
+    if len(time_axis) != len(pkpd.time):
+        raise ValueError("Circuit time axis must match PKPD layer")
+
+    region_names = set(config.region_baseline.keys()) | set(config.region_modulation.keys())
+    for src, targets in config.connectivity.items():
+        region_names.add(src)
+        region_names.update(targets.keys())
+    region_list = sorted(region_names)
+
+    region_activity: Dict[str, list[float]] = {region: [] for region in region_list}
+
+    connectivity = config.connectivity
+    adaptation = 1.0 if config.exposure == "acute" else 1.15
+
+    for idx, _ in enumerate(time_axis):
+        effect = pkpd.effect_site[idx]
+        for region in region_list:
+            baseline = config.region_baseline.get(region, 0.0)
+            modulation = config.region_modulation.get(region, 0.0)
+            recurrent = sum(
+                connectivity.get(region, {}).get(target, 0.0)
+                * config.region_modulation.get(target, 0.0)
+                for target in region_list
+            )
+            level = baseline + adaptation * (modulation * effect + 0.1 * recurrent)
+            region_activity[region].append(level)
+
+    metric_traces: Dict[str, list[float]] = {}
+    for metric, weights in METRIC_REGION_WEIGHTS.items():
+        trace: list[float] = []
+        for t_idx in range(len(time_axis)):
+            value = 0.0
+            for region, weight in weights.items():
+                series = region_activity.get(region)
+                region_value = series[t_idx] if series else 0.0
+                value += weight * region_value
+            trace.append(value)
+        metric_traces[metric] = trace
+
+    behavioural_summary: Dict[str, float] = {}
+    uncertainty: Dict[str, float] = {}
+    for metric, trace in metric_traces.items():
+        mean_val = sum(trace) / len(trace) if trace else 0.0
+        score = 50.0 + (mean_val * 20.0)
+        if metric == "apathy":
+            score = 100.0 - score
+        score = max(0.0, min(100.0, score))
+        readable_name = SCORE_NAME_MAP[metric]
+        behavioural_summary[readable_name] = score
+        base_unc = abs(mean_val) * 0.1
+        propagated = base_unc + pkpd.uncertainty.get("effect_site", 0.05)
+        if not config.propagate_uncertainty:
+            propagated *= 0.5
+        uncertainty[readable_name] = propagated
+
+    region_uncertainty = {}
+    for region, series in region_activity.items():
+        mean_val = sum(series) / len(series) if series else 0.0
+        propagated = abs(mean_val) * 0.05 + pkpd.uncertainty.get("brain_concentration", 0.05)
+        if not config.propagate_uncertainty:
+            propagated *= 0.5
+        region_uncertainty[region] = propagated
+
+    uncertainty["global"] = sum(uncertainty.values()) / max(len(uncertainty), 1)
+
+    return CircuitResult(
+        time=time_axis,
+        region_activity=region_activity,
+        metric_traces=metric_traces,
+        behavioural_summary=behavioural_summary,
+        uncertainty=uncertainty,
+        region_uncertainty=region_uncertainty,
+    )

--- a/backend/simulation/engine.py
+++ b/backend/simulation/engine.py
@@ -1,0 +1,222 @@
+"""Coordinator for the multiscale simulation pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+from ..engine.receptors import canonical_receptor_name, get_mechanism_factor
+from .molecular import LigandContext, MolecularConfig, MolecularResult
+from .molecular import simulate_molecular_layer
+from .molecular import ExposureMode
+from .pkpd import PKPDConfig, PKPDResult, simulate_pkpd
+from .circuit import CircuitConfig, CircuitResult, simulate_circuit
+
+
+KG_RECEPTOR_PARAMETERS: Mapping[str, Mapping[str, object]] = {
+    "5-HT1A": {
+        "ki_nm": 1.4,
+        "expression": 0.9,
+        "region_weights": {"PFC": -0.2, "Hippocampus": 0.3, "Amygdala": -0.25},
+    },
+    "5-HT1B": {
+        "ki_nm": 3.0,
+        "expression": 0.65,
+        "region_weights": {"Striatum": -0.3, "VTA": -0.2},
+    },
+    "5-HT2A": {
+        "ki_nm": 2.0,
+        "expression": 0.8,
+        "region_weights": {"PFC": 0.45, "Hippocampus": 0.2},
+    },
+    "5-HT2C": {
+        "ki_nm": 4.5,
+        "expression": 0.7,
+        "region_weights": {"Striatum": -0.4, "VTA": -0.25},
+    },
+    "5-HT3": {
+        "ki_nm": 8.0,
+        "expression": 0.5,
+        "region_weights": {"PFC": -0.3, "Amygdala": 0.25},
+    },
+    "5-HT7": {
+        "ki_nm": 6.0,
+        "expression": 0.6,
+        "region_weights": {"Thalamus": 0.4, "Hippocampus": 0.3},
+    },
+    "MT2": {
+        "ki_nm": 12.0,
+        "expression": 0.4,
+        "region_weights": {"Thalamus": 0.5, "Hippocampus": 0.2},
+    },
+}
+
+DEFAULT_REGION_BASELINE: Dict[str, float] = {
+    "PFC": 0.1,
+    "Striatum": 0.12,
+    "VTA": 0.1,
+    "Hippocampus": 0.08,
+    "Amygdala": 0.07,
+    "Thalamus": 0.09,
+}
+
+DEFAULT_CONNECTIVITY: Mapping[str, Mapping[str, float]] = {
+    "PFC": {"Striatum": 0.3, "Hippocampus": 0.2},
+    "Striatum": {"PFC": 0.2, "VTA": 0.3},
+    "VTA": {"Striatum": 0.25},
+    "Hippocampus": {"PFC": 0.15, "Thalamus": 0.1},
+    "Amygdala": {"PFC": 0.1},
+    "Thalamus": {"PFC": 0.05},
+}
+
+
+@dataclass(frozen=True)
+class ReceptorInput:
+    """User supplied receptor state derived from the knowledge graph."""
+
+    occupancy: float
+    mechanism: str
+
+
+@dataclass(frozen=True)
+class SimulationConfig:
+    """Top level configuration consumed by :func:`run_multiscale_pipeline`."""
+
+    receptors: Mapping[str, ReceptorInput]
+    exposure: ExposureMode
+    adhd: bool = False
+    gut_bias: bool = False
+    pvt_weight: float = 0.5
+    propagate_uncertainty: bool = True
+
+
+@dataclass
+class MultiscaleResult:
+    """Composite result for the multi-layer simulation."""
+
+    time: list[float]
+    molecular: MolecularResult
+    pkpd: PKPDResult
+    circuit: CircuitResult
+    behavioural_scores: Dict[str, float]
+    uncertainty_breakdown: Dict[str, Dict[str, float]]
+
+
+def _time_axis() -> list[float]:
+    return [float(t) for t in range(0, 241, 10)]
+
+
+def _build_ligand_contexts(config: SimulationConfig) -> tuple[Dict[str, LigandContext], Dict[str, float]]:
+    ligands: Dict[str, LigandContext] = {}
+    region_modulation: Dict[str, float] = {region: 0.0 for region in DEFAULT_REGION_BASELINE}
+
+    for name, rec_input in config.receptors.items():
+        canon = canonical_receptor_name(name)
+        params = KG_RECEPTOR_PARAMETERS.get(canon)
+        if not params:
+            continue
+        mechanism_factor = get_mechanism_factor(rec_input.mechanism)
+        ligands[canon] = LigandContext(
+            receptor=canon,
+            occupancy=rec_input.occupancy,
+            mechanism_factor=mechanism_factor,
+            ki_nm=float(params["ki_nm"]),
+            expression=float(params["expression"]),
+        )
+        region_weights = params.get("region_weights", {})
+        for region, weight in region_weights.items():
+            region_modulation[region] = region_modulation.get(region, 0.0) + (
+                mechanism_factor * rec_input.occupancy * float(weight)
+            )
+
+    return ligands, region_modulation
+
+
+def _adjust_baselines(config: SimulationConfig) -> Dict[str, float]:
+    baseline = dict(DEFAULT_REGION_BASELINE)
+    if config.adhd:
+        baseline["Striatum"] = baseline.get("Striatum", 0.0) - 0.03
+        baseline["PFC"] = baseline.get("PFC", 0.0) + 0.02
+    if config.gut_bias:
+        for region in ("Hippocampus", "Thalamus"):
+            baseline[region] = baseline.get(region, 0.0) + 0.02
+    return baseline
+
+
+def run_multiscale_pipeline(config: SimulationConfig) -> MultiscaleResult:
+    """Execute the molecular → PKPD → circuit pipeline and summarise behaviour."""
+
+    time_axis = _time_axis()
+    ligands, region_modulation = _build_ligand_contexts(config)
+
+    molecular = simulate_molecular_layer(
+        MolecularConfig(
+            time=time_axis,
+            ligands=ligands,
+            exposure=config.exposure,
+            propagate_uncertainty=config.propagate_uncertainty,
+        )
+    )
+
+    clearance = 6.0 if config.exposure == "acute" else 12.0
+    bioavailability = 0.5 + (0.25 * max(0.0, min(1.0, config.pvt_weight)))
+
+    pkpd = simulate_pkpd(
+        PKPDConfig(
+            time=time_axis,
+            exposure=config.exposure,
+            propagate_uncertainty=config.propagate_uncertainty,
+            clearance_half_life_hr=clearance,
+            bioavailability=bioavailability,
+        ),
+        molecular,
+    )
+
+    baseline = _adjust_baselines(config)
+
+    circuit = simulate_circuit(
+        CircuitConfig(
+            time=time_axis,
+            exposure=config.exposure,
+            region_baseline=baseline,
+            region_modulation=region_modulation,
+            connectivity=DEFAULT_CONNECTIVITY,
+            propagate_uncertainty=config.propagate_uncertainty,
+        ),
+        pkpd,
+    )
+
+    scores = dict(circuit.behavioural_summary)
+
+    if config.adhd:
+        scores["DriveInvigoration"] = max(0.0, scores["DriveInvigoration"] - 5.0)
+        scores["Motivation"] = max(0.0, scores["Motivation"] - 4.0)
+    if config.gut_bias:
+        scores["ApathyBlunting"] = min(100.0, scores["ApathyBlunting"] + 3.0)
+    if config.exposure == "chronic":
+        scores["SleepQuality"] = min(100.0, scores["SleepQuality"] + 2.0)
+
+    uncertainty_breakdown: Dict[str, Dict[str, float]] = {
+        "molecular": dict(molecular.uncertainty),
+        "pkpd": dict(pkpd.uncertainty),
+        "circuit": dict(circuit.uncertainty),
+        "regions": dict(circuit.region_uncertainty),
+        "combined": {},
+    }
+
+    for metric in scores:
+        combined = (
+            circuit.uncertainty.get(metric, 0.0)
+            + pkpd.uncertainty.get("effect_site", 0.0)
+            + molecular.uncertainty.get("global", 0.0)
+        )
+        uncertainty_breakdown["combined"][metric] = combined
+
+    return MultiscaleResult(
+        time=time_axis,
+        molecular=molecular,
+        pkpd=pkpd,
+        circuit=circuit,
+        behavioural_scores=scores,
+        uncertainty_breakdown=uncertainty_breakdown,
+    )

--- a/backend/simulation/molecular.py
+++ b/backend/simulation/molecular.py
@@ -1,0 +1,117 @@
+"""Interfaces for receptor and intracellular cascade simulations.
+
+This module provides a deterministic surrogate for the PySB models that would
+normally capture ligand–receptor interactions and downstream signalling
+cascades.  The goal is to expose a stable, typed contract for higher level
+orchestration code and unit tests.  The actual PySB models can be swapped in by
+replacing :func:`simulate_molecular_layer` with a wrapper that calls the
+pre‑compiled models once they are available in the deployment environment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Sequence, Literal
+import math
+
+
+ExposureMode = Literal["acute", "chronic"]
+
+
+@dataclass(frozen=True)
+class LigandContext:
+    """Contextual information for a single receptor–ligand pairing."""
+
+    receptor: str
+    occupancy: float
+    mechanism_factor: float
+    ki_nm: float
+    expression: float
+
+
+@dataclass(frozen=True)
+class MolecularConfig:
+    """Configuration for the molecular layer simulation."""
+
+    time: Sequence[float]
+    ligands: Mapping[str, LigandContext]
+    exposure: ExposureMode
+    propagate_uncertainty: bool = True
+
+
+@dataclass
+class MolecularResult:
+    """Time-resolved receptor activity and signalling readouts."""
+
+    time: list[float]
+    receptor_activity: Dict[str, list[float]]
+    cascade_activity: Dict[str, list[float]]
+    uncertainty: Dict[str, float]
+
+
+def _validate_time_axis(time: Sequence[float]) -> None:
+    if not time:
+        raise ValueError("time axis must contain at least one element")
+    previous = time[0]
+    for t in time[1:]:
+        if t < previous:
+            raise ValueError("time axis must be monotonically increasing")
+        previous = t
+
+
+def simulate_molecular_layer(config: MolecularConfig) -> MolecularResult:
+    """Simulate receptor occupancy cascades using analytic surrogates.
+
+    Parameters
+    ----------
+    config:
+        Dataclass containing ligand contexts and the simulation horizon.
+
+    Returns
+    -------
+    MolecularResult
+        A structure containing receptor level activity, aggregate cascade
+        activity, and analytic uncertainty estimates.
+    """
+
+    _validate_time_axis(config.time)
+
+    receptor_activity: Dict[str, list[float]] = {}
+    uncertainties: Dict[str, float] = {}
+
+    if not config.ligands:
+        cascade = [0.0 for _ in config.time]
+    else:
+        cascade = [0.0 for _ in config.time]
+
+    tau = 45.0 if config.exposure == "acute" else 180.0
+    adaptation = 1.0 if config.exposure == "acute" else 1.2
+
+    for name, ctx in config.ligands.items():
+        affinity_scale = 1.0 / (1.0 + (ctx.ki_nm / 10.0))
+        amplitude = ctx.expression * ctx.occupancy * ctx.mechanism_factor
+        amplitude *= affinity_scale * adaptation
+        trace = [float(amplitude * (1.0 - math.exp(-t / tau))) for t in config.time]
+        receptor_activity[name] = trace
+        for idx, value in enumerate(trace):
+            cascade[idx] += value
+        base_unc = abs(amplitude) * 0.05 if config.propagate_uncertainty else 0.0
+        uncertainties[name] = max(0.01, base_unc)
+
+    if receptor_activity:
+        n = float(len(receptor_activity))
+        cascade = [val / n for val in cascade]
+
+    global_uncertainty = (
+        sum(uncertainties.values()) / len(uncertainties) if uncertainties else 0.01
+    )
+    uncertainties["global"] = global_uncertainty
+
+    cascade_activity = {"net_serotonin_modulation": cascade}
+
+    return MolecularResult(
+        time=list(config.time),
+        receptor_activity=receptor_activity,
+        cascade_activity=cascade_activity,
+        uncertainty=uncertainties,
+    )

--- a/backend/simulation/pkpd.py
+++ b/backend/simulation/pkpd.py
@@ -1,0 +1,75 @@
+"""PBPK/PKPD layer wrapping Open Systems Pharmacology style models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Sequence
+import math
+
+from .molecular import ExposureMode, MolecularResult
+
+
+@dataclass(frozen=True)
+class PKPDConfig:
+    """Configuration for the pharmacokinetic/pharmacodynamic layer."""
+
+    time: Sequence[float]
+    exposure: ExposureMode
+    propagate_uncertainty: bool = True
+    clearance_half_life_hr: float = 6.0
+    bioavailability: float = 0.6
+
+
+@dataclass
+class PKPDResult:
+    """Effect-site concentration time course and derived statistics."""
+
+    time: list[float]
+    brain_concentration: list[float]
+    effect_site: list[float]
+    uncertainty: Dict[str, float]
+
+
+def simulate_pkpd(config: PKPDConfig, molecular: MolecularResult) -> PKPDResult:
+    """Simulate a reduced PKPD model driven by molecular activity."""
+
+    time_axis = list(config.time)
+
+    if len(time_axis) != len(molecular.time):
+        raise ValueError("PKPD time axis must match molecular layer")
+
+    clearance_half_life = config.clearance_half_life_hr
+    if config.exposure == "chronic":
+        clearance_half_life *= 1.5
+    elimination_constant = math.log(2.0) / max(clearance_half_life, 1e-3)
+
+    brain_conc: list[float] = []
+    effect_site: list[float] = []
+
+    cascade = molecular.cascade_activity.get("net_serotonin_modulation", [0.0] * len(time_axis))
+
+    previous = 0.0
+    previous_time = time_axis[0]
+    for idx, time_point in enumerate(time_axis):
+        signal = cascade[idx]
+        dt = time_point - previous_time if idx else 0.0
+        previous_time = time_point
+        delta = (signal * config.bioavailability) - (previous * elimination_constant * dt)
+        level = previous + delta
+        previous = level
+        brain_conc.append(level)
+        effect_site.append(level * 0.8)
+
+    base_unc = molecular.uncertainty.get("global", 0.05)
+    propagated_unc = base_unc * (0.5 if not config.propagate_uncertainty else 1.0)
+    uncertainty = {
+        "brain_concentration": propagated_unc,
+        "effect_site": propagated_unc * 1.1,
+    }
+
+    return PKPDResult(
+        time=time_axis,
+        brain_concentration=brain_conc,
+        effect_site=effect_site,
+        uncertainty=uncertainty,
+    )

--- a/backend/tests/test_simulation_pipeline.py
+++ b/backend/tests/test_simulation_pipeline.py
@@ -1,0 +1,97 @@
+"""Regression tests for the multiscale simulation pipeline."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.main import app
+from backend.simulation import ReceptorInput, SimulationConfig, run_multiscale_pipeline
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_chronic_ssri_regression() -> None:
+    """Chronic SSRI scenario should remain numerically stable over time."""
+
+    config = SimulationConfig(
+        receptors={
+            "5-HT1A": ReceptorInput(occupancy=0.7, mechanism="agonist"),
+            "5-HT1B": ReceptorInput(occupancy=0.4, mechanism="partial"),
+            "5-HT2C": ReceptorInput(occupancy=0.3, mechanism="antagonist"),
+            "5-HT7": ReceptorInput(occupancy=0.5, mechanism="agonist"),
+        },
+        exposure="chronic",
+        adhd=False,
+        gut_bias=False,
+        pvt_weight=0.4,
+        propagate_uncertainty=True,
+    )
+
+    result = run_multiscale_pipeline(config)
+
+    expected_scores = {
+        "DriveInvigoration": 52.348964366858326,
+        "ApathyBlunting": 50.68958768827599,
+        "Motivation": 52.30007586034499,
+        "CognitiveFlexibility": 52.10645724022999,
+        "Anxiety": 50.45335109588086,
+        "SleepQuality": 53.4930238115713,
+    }
+    for key, expected in expected_scores.items():
+        assert result.behavioural_scores[key] == pytest.approx(expected)
+
+    combined_uncertainty = {
+        "DriveInvigoration": 0.06327113762376532,
+        "ApathyBlunting": 0.054974254230853635,
+        "Motivation": 0.06302669509119863,
+        "CognitiveFlexibility": 0.062058601990623644,
+        "Anxiety": 0.053793071268878015,
+        "SleepQuality": 0.058991434847330174,
+    }
+    for key, expected in combined_uncertainty.items():
+        assert result.uncertainty_breakdown["combined"][key] == pytest.approx(expected)
+
+
+def test_simulate_endpoint_uncertainty_toggle(client: TestClient) -> None:
+    """Endpoint exposes time series and responds to uncertainty toggles."""
+
+    payload = {
+        "receptors": {"5-HT1A": {"occ": 0.6, "mech": "agonist"}},
+        "adhd": True,
+        "gut_bias": False,
+        "pvt_weight": 0.5,
+        "exposure": "acute",
+        "propagate_uncertainty": False,
+    }
+
+    response = client.post("/simulate", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+
+    scores = body["scores"]
+    assert set(scores) == {
+        "DriveInvigoration",
+        "ApathyBlunting",
+        "Motivation",
+        "CognitiveFlexibility",
+        "Anxiety",
+        "SleepQuality",
+    }
+
+    details = body["details"]
+    assert details["assumptions"]["exposure"] == "acute"
+    assert details["assumptions"]["propagate_uncertainty"] is False
+    assert len(details["time"]) > 10
+    assert details["uncertainty"]["molecular"]["global"] == pytest.approx(0.01)
+
+    combined = details["uncertainty"]["combined"]["DriveInvigoration"]
+    assert combined < 0.05  # toggle suppresses uncertainty propagation


### PR DESCRIPTION
## Summary
- add a typed `backend/simulation` package that wraps molecular, PK/PD, and circuit surrogate models and coordinates them via a multiscale engine
- refactor `/simulate` to run the new pipeline, expose acute vs chronic switches, and return per-layer time series with uncertainty
- expand backend documentation and dependencies to cover PySB, TVB, PK-Sim, and add regression tests for the chronic SSRI scenario and uncertainty toggles

## Testing
- python -m compileall backend/main.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ce6a69b6a0832980755590f81aeabd