### PR TITLE
Add multi-layer simulation engine and chronic scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Three.js) to explore the model in real time.
 neuropharm-sim-lab/
 ├── backend
 │   ├── engine/          # definitions of receptors, weights and helper functions
+│   ├── simulation/      # PySB, PK/PD, and circuit orchestration layers
 │   │   ├── __init__.py
 │   │   └── receptors.py
 │   ├── main.py          # FastAPI app exposing the simulation endpoint
@@ -40,6 +41,24 @@ neuropharm-sim-lab/
 │       └── deploy-frontend.yml # GitHub Actions workflow for Pages deployment
 └── README.md
 ```
+
+## Simulation engine architecture
+
+The backend simulation stack is split into three modular layers beneath
+`backend/simulation/`:
+
+1. **`molecular.py`** converts knowledge-graph derived receptor occupancies
+   into PySB-style cascades, returning time-varying activity for CREB, BDNF,
+   and other downstream effectors.
+2. **`pkpd.py`** approximates Open Systems Pharmacology / PBPK workflows to
+   produce plasma and brain concentration profiles under acute or chronic
+   dosing assumptions.
+3. **`circuit.py`** emulates The Virtual Brain coupling to summarise regional
+   activation dynamics in cortico-striatal-amygdala loops.
+
+`engine.py` orchestrates these layers, aligns their time grids, and produces
+behavioural scores with associated confidence intervals based on the evidence
+density captured in the knowledge graph.
 
 ## Knowledge graph data layer
 
@@ -140,6 +159,14 @@ call-outs for screenshots you can capture or replace later.
      cd backend
      pip install -r requirements.txt
      ```
+
+     The optional scientific toolkits listed at the end of
+     `backend/requirements.txt` – `PySB`, `OSPSuite`, and
+     `tvb-library` – enable the full molecular cascade, PBPK, and brain
+     network integrations. They are not required for the lightweight test
+     harness used in this repository, but you should install them when you
+     plan to run external PySB models, Open Systems Pharmacology workflows,
+     or The Virtual Brain coupling experiments.
 
    * Start the FastAPI server:
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,9 @@ numpy>=1.22.0
 scipy>=1.8.0
 pydantic>=2.1.1
 requests>=2.31.0
+httpx>=0.27.0
+# Optional domain toolkits leveraged by the simulation orchestration layer
+# (install when running full PySB/OSP/TVB integrations)
+pysb>=1.13.0
+ospsuite>=11.0.0
+tvb-library>=2.8.0

--- a/backend/simulation/__init__.py
+++ b/backend/simulation/__init__.py
@@ -1,0 +1,27 @@
+"""Simulation layer primitives for the Neuropharm backend."""
+
+from .engine import (
+    EngineRequest,
+    EngineResult,
+    ReceptorEngagement,
+    SimulationEngine,
+)
+from .molecular import MolecularCascadeParams, MolecularCascadeResult, simulate_cascade
+from .pkpd import PKPDParameters, PKPDProfile, simulate_pkpd
+from .circuit import CircuitParameters, CircuitResponse, simulate_circuit_response
+
+__all__ = [
+    "EngineRequest",
+    "EngineResult",
+    "ReceptorEngagement",
+    "SimulationEngine",
+    "MolecularCascadeParams",
+    "MolecularCascadeResult",
+    "simulate_cascade",
+    "PKPDParameters",
+    "PKPDProfile",
+    "simulate_pkpd",
+    "CircuitParameters",
+    "CircuitResponse",
+    "simulate_circuit_response",
+]

--- a/backend/simulation/circuit.py
+++ b/backend/simulation/circuit.py
@@ -1,0 +1,85 @@
+"""TVB-inspired neural circuit coupling placeholders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Sequence, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+
+@dataclass(frozen=True)
+class CircuitParameters:
+    """Parameters for the Virtual Brain style coupling step."""
+
+    regions: Sequence[str]
+    connectivity: Mapping[Tuple[str, str], float]
+    neuromodulator_drive: Mapping[str, float]
+    regimen: str
+    timepoints: Sequence[float]
+    coupling_baseline: float
+    kg_confidence: float
+
+
+@dataclass(frozen=True)
+class CircuitResponse:
+    """Outputs from the circuit integration."""
+
+    timepoints: npt.NDArray[np.float64]
+    region_activity: Dict[str, npt.NDArray[np.float64]]
+    global_metrics: Dict[str, float]
+    uncertainty: Dict[str, float]
+
+
+def simulate_circuit_response(params: CircuitParameters) -> CircuitResponse:
+    """Integrate a coarse network response with neuromodulator drives."""
+
+    if len(params.timepoints) == 0:
+        raise ValueError("timepoints must contain at least one value")
+
+    time = np.asarray(params.timepoints, dtype=float)
+    if np.any(np.diff(time) <= 0):
+        raise ValueError("timepoints must be strictly increasing")
+
+    serotonin_drive = params.neuromodulator_drive.get("serotonin", 0.0)
+    dopamine_drive = params.neuromodulator_drive.get("dopamine", 0.0)
+    noradrenaline_drive = params.neuromodulator_drive.get("noradrenaline", 0.0)
+
+    drive_gain = params.coupling_baseline + 0.6 * serotonin_drive + 0.3 * dopamine_drive + 0.2 * noradrenaline_drive
+    drive_gain = max(drive_gain, 1e-3)
+    regimen_gain = 1.15 if params.regimen == "chronic" else 1.0
+
+    region_activity: Dict[str, npt.NDArray[np.float64]] = {}
+    for region in params.regions:
+        coupling_sum = sum(params.connectivity.get((region, other), 0.0) for other in params.regions)
+        effective_gain = drive_gain + 0.4 * coupling_sum
+        effective_gain = max(effective_gain, 1e-3)
+        response = effective_gain * (1.0 - np.exp(-0.12 * (time - time[0]))) * regimen_gain
+        region_activity[region] = response.astype(float, copy=False)
+
+    stacked = np.vstack(list(region_activity.values()))
+    mean_activity = stacked.mean(axis=0)
+    variance = stacked.var(axis=0)
+
+    drive_index = float(np.clip(mean_activity[-1] / (1.0 + mean_activity[-1]), 0.0, 1.0))
+    flexibility_index = float(np.clip(np.mean(variance) * 0.5, 0.0, 1.0))
+    anxiety_index = float(np.clip(0.4 - 0.2 * serotonin_drive + 0.1 * noradrenaline_drive, 0.0, 1.0))
+    apathy_index = float(np.clip(1.0 - drive_index * 0.85, 0.0, 1.0))
+
+    uncertainty = {
+        "network": float(max(0.05, 1.0 - np.clip(params.kg_confidence, 0.0, 1.0))),
+    }
+    global_metrics = {
+        "drive_index": drive_index,
+        "flexibility_index": flexibility_index,
+        "anxiety_index": anxiety_index,
+        "apathy_index": apathy_index,
+    }
+
+    return CircuitResponse(
+        timepoints=time,
+        region_activity=region_activity,
+        global_metrics=global_metrics,
+        uncertainty=uncertainty,
+    )

--- a/backend/simulation/engine.py
+++ b/backend/simulation/engine.py
@@ -1,0 +1,206 @@
+"""High level simulation orchestration layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, MutableMapping, Literal
+
+import numpy as np
+
+from .circuit import CircuitParameters, simulate_circuit_response
+from .molecular import MolecularCascadeParams, simulate_cascade
+from .pkpd import PKPDParameters, simulate_pkpd
+
+Mechanism = Literal["agonist", "antagonist", "partial", "inverse"]
+
+
+@dataclass(frozen=True)
+class ReceptorEngagement:
+    """Normalised receptor engagement derived from the knowledge graph."""
+
+    name: str
+    occupancy: float
+    mechanism: Mechanism
+    kg_weight: float
+    evidence: float
+
+
+@dataclass(frozen=True)
+class EngineRequest:
+    """Input payload for the orchestration layer."""
+
+    receptors: Mapping[str, ReceptorEngagement]
+    regimen: Literal["acute", "chronic"]
+    adhd: bool
+    gut_bias: bool
+    pvt_weight: float
+
+
+@dataclass(frozen=True)
+class EngineResult:
+    """Structured result returned by :class:`SimulationEngine`."""
+
+    scores: Dict[str, float]
+    timepoints: list[float]
+    trajectories: Dict[str, list[float]]
+    module_summaries: Dict[str, Any]
+    confidence: Dict[str, float]
+
+
+class SimulationEngine:
+    """Coordinate the molecular, PK/PD, and circuit layers."""
+
+    def __init__(self, time_step: float = 1.0) -> None:
+        self.time_step = time_step
+
+    def run(self, request: EngineRequest) -> EngineResult:
+        """Execute the multi-layer simulation."""
+
+        horizon = 24.0 if request.regimen == "acute" else 24.0 * 7
+        timepoints = np.arange(0.0, horizon + self.time_step, self.time_step)
+
+        receptor_states: Dict[str, float] = {
+            name: engagement.occupancy for name, engagement in request.receptors.items()
+        }
+        receptor_weights: Dict[str, float] = {
+            name: engagement.kg_weight for name, engagement in request.receptors.items()
+        }
+        receptor_evidence: Dict[str, float] = {
+            name: engagement.evidence for name, engagement in request.receptors.items()
+        }
+        mean_evidence = float(np.mean(list(receptor_evidence.values()) or [0.5]))
+
+        molecular_params = MolecularCascadeParams(
+            pathway="monoamine_neurotrophin_cascade",
+            receptor_states=receptor_states,
+            receptor_weights=receptor_weights,
+            receptor_evidence=receptor_evidence,
+            downstream_nodes={"CREB": 0.18, "BDNF": 0.09, "mTOR": 0.05},
+            stimulus=1.2 if request.regimen == "chronic" else 1.0,
+            timepoints=timepoints,
+        )
+        molecular_result = simulate_cascade(molecular_params)
+
+        avg_occ = float(np.mean(list(receptor_states.values()) or [0.0]))
+        dose_mg = 50.0 * max(0.25, avg_occ)
+        clearance_rate = 0.15 if request.regimen == "acute" else 0.08
+        pkpd_params = PKPDParameters(
+            compound="composite_ssri",
+            dose_mg=dose_mg,
+            dosing_interval_h=24.0,
+            regimen=request.regimen,
+            clearance_rate=clearance_rate,
+            bioavailability=0.55 + 0.35 * avg_occ,
+            brain_plasma_ratio=0.75 + 0.1 * avg_occ,
+            receptor_occupancy=receptor_states,
+            kg_confidence=mean_evidence,
+            simulation_hours=horizon,
+            time_step=self.time_step,
+        )
+        pkpd_profile = simulate_pkpd(pkpd_params)
+
+        serotonin_drive = float(np.tanh(molecular_result.summary["steady_state"]))
+        dopamine_drive = float(
+            np.tanh(molecular_result.summary["transient_peak"] * (1.0 - request.pvt_weight * 0.3))
+        )
+        noradrenaline_drive = float(np.tanh(molecular_result.summary["activation_index"] * 0.5))
+
+        if request.adhd:
+            dopamine_drive *= 0.85
+            noradrenaline_drive *= 0.9
+        if request.gut_bias:
+            serotonin_drive *= 1.05
+
+        auc_scaled = float(np.tanh(pkpd_profile.summary["auc"] / 100.0))
+        connectivity: MutableMapping[tuple[str, str], float] = {}
+        regions = ("prefrontal", "striatum", "amygdala")
+        for src in regions:
+            for dst in regions:
+                if src == dst:
+                    continue
+                connectivity[(src, dst)] = 0.2 + 0.3 * auc_scaled
+
+        circuit_params = CircuitParameters(
+            regions=regions,
+            connectivity=connectivity,
+            neuromodulator_drive={
+                "serotonin": serotonin_drive,
+                "dopamine": dopamine_drive,
+                "noradrenaline": noradrenaline_drive,
+            },
+            regimen=request.regimen,
+            timepoints=timepoints,
+            coupling_baseline=0.25 + 0.4 * auc_scaled,
+            kg_confidence=mean_evidence,
+        )
+        circuit_response = simulate_circuit_response(circuit_params)
+
+        def _score_from_index(index: float, invert: bool = False) -> float:
+            centred = 50.0 + 100.0 * (index - 0.5)
+            if invert:
+                centred = 100.0 - centred
+            return float(max(0.0, min(100.0, centred)))
+
+        scores: Dict[str, float] = {
+            "DriveInvigoration": _score_from_index(circuit_response.global_metrics["drive_index"]),
+            "ApathyBlunting": _score_from_index(circuit_response.global_metrics["apathy_index"], invert=True),
+            "Motivation": _score_from_index(
+                0.5 * circuit_response.global_metrics["drive_index"]
+                + 0.5 * np.clip(molecular_result.summary["activation_index"], 0.0, 1.0)
+            ),
+            "CognitiveFlexibility": _score_from_index(circuit_response.global_metrics["flexibility_index"]),
+            "Anxiety": _score_from_index(circuit_response.global_metrics["anxiety_index"], invert=True),
+            "SleepQuality": _score_from_index(1.0 - pkpd_profile.uncertainty["exposure"]),
+        }
+
+        if request.adhd:
+            scores["Motivation"] = max(0.0, scores["Motivation"] - 5.0)
+            scores["CognitiveFlexibility"] = max(0.0, scores["CognitiveFlexibility"] - 4.0)
+        if request.gut_bias:
+            scores["SleepQuality"] = min(100.0, scores["SleepQuality"] + 3.0)
+            scores["Anxiety"] = min(100.0, scores["Anxiety"] + 4.0)
+
+        module_uncertainties = {
+            "molecular": molecular_result.uncertainty["cascade"],
+            "pkpd": pkpd_profile.uncertainty["pkpd"],
+            "circuit": circuit_response.uncertainty["network"],
+        }
+        base_conf = float(max(0.05, 1.0 - np.mean(list(module_uncertainties.values()))))
+        confidence = {
+            metric: float(
+                max(
+                    0.05,
+                    min(
+                        0.99,
+                        base_conf
+                        * (1.0 - 0.3 * module_uncertainties["molecular"])
+                        * (1.0 - 0.3 * module_uncertainties["pkpd"])
+                        * (1.0 - 0.4 * module_uncertainties["circuit"]),
+                    ),
+                )
+            )
+            for metric in scores.keys()
+        }
+
+        trajectories = {
+            "plasma_concentration": pkpd_profile.plasma_concentration.astype(float).tolist(),
+            "brain_concentration": pkpd_profile.brain_concentration.astype(float).tolist(),
+        }
+        for node, values in molecular_result.node_activity.items():
+            trajectories[f"cascade_{node.lower()}"] = values.astype(float).tolist()
+        for region, values in circuit_response.region_activity.items():
+            trajectories[f"region_{region.lower()}"] = values.astype(float).tolist()
+
+        module_summaries: Dict[str, Any] = {
+            "molecular": molecular_result.summary,
+            "pkpd": pkpd_profile.summary,
+            "circuit": circuit_response.global_metrics,
+        }
+
+        return EngineResult(
+            scores=scores,
+            timepoints=timepoints.astype(float).tolist(),
+            trajectories=trajectories,
+            module_summaries=module_summaries,
+            confidence=confidence,
+        )

--- a/backend/simulation/molecular.py
+++ b/backend/simulation/molecular.py
@@ -1,0 +1,125 @@
+"""PySB-inspired molecular cascade utilities.
+
+The real project integrates PySB models compiled from the knowledge graph.  The
+helpers defined here provide a typed, numerically stable placeholder that
+accepts the same style of parameters: receptor occupancies derived from the
+knowledge graph, weightings for each downstream node, and evidence/confidence
+scores that quantify how trustworthy the pathway wiring is.  The placeholder
+uses simple analytic solutions to keep the tests fast while exercising the
+interfaces expected by the orchestration engine.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Sequence
+
+import numpy as np
+import numpy.typing as npt
+
+
+@dataclass(frozen=True)
+class MolecularCascadeParams:
+    """Container for PySB cascade inputs.
+
+    Parameters
+    ----------
+    pathway:
+        Identifier of the signalling pathway being simulated.
+    receptor_states:
+        Mapping of receptor names to fractional occupancy (0-1 range).
+    receptor_weights:
+        Relative influence of each receptor on the pathway activation.
+    receptor_evidence:
+        Confidence scores supplied by the knowledge graph (0-1 range).
+    downstream_nodes:
+        Mapping of downstream node names to effective rate constants.
+    stimulus:
+        Global scaling factor capturing ligand stimulus strength.
+    timepoints:
+        Ordered sequence of simulation timepoints (hours).
+    """
+
+    pathway: str
+    receptor_states: Mapping[str, float]
+    receptor_weights: Mapping[str, float]
+    receptor_evidence: Mapping[str, float]
+    downstream_nodes: Mapping[str, float]
+    stimulus: float
+    timepoints: Sequence[float]
+
+
+@dataclass(frozen=True)
+class MolecularCascadeResult:
+    """Result of a cascade simulation."""
+
+    timepoints: npt.NDArray[np.float64]
+    node_activity: Dict[str, npt.NDArray[np.float64]]
+    summary: Dict[str, float]
+    uncertainty: Dict[str, float]
+
+
+def simulate_cascade(params: MolecularCascadeParams) -> MolecularCascadeResult:
+    """Compute a smooth cascade response for the provided parameters.
+
+    The placeholder implementation applies an exponential convergence to a
+    receptor-weighted stimulus.  It preserves the deterministic structure of
+    the real PySB model while keeping the dependency footprint minimal.
+    """
+
+    if len(params.timepoints) == 0:
+        raise ValueError("timepoints must contain at least one value")
+
+    time = np.asarray(params.timepoints, dtype=float)
+    if np.any(np.diff(time) <= 0):
+        raise ValueError("timepoints must be strictly increasing")
+
+    # Aggregate receptor influence using knowledge-graph weights.  Mechanistic
+    # evidence increases effective stimulus, reflecting higher confidence that
+    # the receptor truly drives the pathway.
+    receptor_effect = 0.0
+    for name, occ in params.receptor_states.items():
+        weight = params.receptor_weights.get(name, 0.5)
+        evidence = params.receptor_evidence.get(name, 0.5)
+        receptor_effect += occ * weight * (0.5 + 0.5 * evidence)
+    receptor_effect *= params.stimulus
+
+    if not params.downstream_nodes:
+        raise ValueError("at least one downstream node must be supplied")
+
+    node_activity: Dict[str, npt.NDArray[np.float64]] = {}
+    for node, rate in params.downstream_nodes.items():
+        rate = max(rate, 1e-3)
+        response = receptor_effect * (1.0 - np.exp(-rate * (time - time[0])))
+        node_activity[node] = response.astype(float, copy=False)
+
+    stacked = np.vstack(list(node_activity.values()))
+    mean_activity = stacked.mean(axis=0)
+
+    transient_peak = float(np.max(mean_activity))
+    steady_state = float(mean_activity[-1])
+    auc = float(np.trapezoid(mean_activity, time))
+    duration = float(time[-1] - time[0])
+    activation_index = float(auc / duration) if duration > 0 else float(mean_activity[-1])
+
+    evidence_values = list(params.receptor_evidence.values()) or [0.5]
+    mean_evidence = float(np.clip(np.mean(evidence_values), 0.0, 1.0))
+    uncertainty_level = float(max(0.05, 1.0 - mean_evidence))
+
+    summary = {
+        "transient_peak": transient_peak,
+        "steady_state": steady_state,
+        "activation_index": activation_index,
+        "pathway": params.pathway,
+    }
+    uncertainty = {
+        "cascade": uncertainty_level,
+        "steady_state": float(max(0.05, 1.0 - mean_evidence * 0.9)),
+    }
+
+    return MolecularCascadeResult(
+        timepoints=time,
+        node_activity=node_activity,
+        summary=summary,
+        uncertainty=uncertainty,
+    )

--- a/backend/simulation/pkpd.py
+++ b/backend/simulation/pkpd.py
@@ -1,0 +1,80 @@
+"""Simplified PK/PD interface bridging to Open Systems Pharmacology or PBPK tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+import numpy as np
+import numpy.typing as npt
+
+
+@dataclass(frozen=True)
+class PKPDParameters:
+    """Inputs describing the dosing scenario and physiological priors."""
+
+    compound: str
+    dose_mg: float
+    dosing_interval_h: float
+    regimen: str  # "acute" or "chronic"
+    clearance_rate: float
+    bioavailability: float
+    brain_plasma_ratio: float
+    receptor_occupancy: Mapping[str, float]
+    kg_confidence: float
+    simulation_hours: float
+    time_step: float = 1.0
+
+
+@dataclass(frozen=True)
+class PKPDProfile:
+    """Output profile for PK/PD simulations."""
+
+    timepoints: npt.NDArray[np.float64]
+    plasma_concentration: npt.NDArray[np.float64]
+    brain_concentration: npt.NDArray[np.float64]
+    summary: Dict[str, float]
+    uncertainty: Dict[str, float]
+
+
+def simulate_pkpd(params: PKPDParameters) -> PKPDProfile:
+    """Integrate a coarse PK/PD profile for the configured regimen."""
+
+    step = max(params.time_step, 1e-3)
+    time = np.arange(0.0, params.simulation_hours + step, step)
+    kel = max(params.clearance_rate, 1e-3)
+    dose = max(params.dose_mg, 0.0) * max(params.bioavailability, 0.0)
+
+    plasma = dose * np.exp(-kel * time)
+    if params.regimen == "chronic":
+        max_doses = int(params.simulation_hours // params.dosing_interval_h)
+        for n in range(1, max_doses + 1):
+            start = n * params.dosing_interval_h
+            mask = time >= start
+            plasma = plasma + dose * np.exp(-kel * (time - start)) * mask
+    brain = plasma * params.brain_plasma_ratio
+
+    auc = float(np.trapezoid(plasma, time))
+    cmax = float(np.max(plasma)) if plasma.size else 0.0
+    exposure_index = float(np.trapezoid(brain, time) / (params.simulation_hours + 1e-6))
+
+    uncertainty = {
+        "pkpd": float(max(0.05, 1.0 - np.clip(params.kg_confidence, 0.0, 1.0))),
+        "exposure": float(max(0.05, 1.0 - np.clip(params.kg_confidence, 0.0, 1.0) * 0.9)),
+    }
+
+    summary = {
+        "auc": auc,
+        "cmax": cmax,
+        "exposure_index": exposure_index,
+        "duration_h": float(params.simulation_hours),
+        "regimen": params.regimen,
+    }
+
+    return PKPDProfile(
+        timepoints=time,
+        plasma_concentration=plasma,
+        brain_concentration=brain,
+        summary=summary,
+        uncertainty=uncertainty,
+    )

--- a/backend/tests/test_main_simulation.py
+++ b/backend/tests/test_main_simulation.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+
+client = TestClient(app)
+
+
+def test_simulate_endpoint_returns_confidence_and_timecourse():
+    payload = {
+        "receptors": {
+            "5HT1A": {"occ": 0.6, "mech": "agonist"},
+            "5HT2A": {"occ": 0.3, "mech": "antagonist"},
+        },
+        "adhd": True,
+        "gut_bias": False,
+        "pvt_weight": 0.4,
+        "dosing": "chronic",
+    }
+
+    response = client.post("/simulate", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "confidence" in data
+    assert "DriveInvigoration" in data["scores"]
+    assert 0.0 <= data["confidence"]["DriveInvigoration"] <= 1.0
+    assert len(data["details"]["timepoints"]) == len(data["details"]["trajectories"]["plasma_concentration"])
+    assert data["details"]["timepoints"][-1] >= 168.0

--- a/backend/tests/test_simulation_engine.py
+++ b/backend/tests/test_simulation_engine.py
@@ -1,0 +1,39 @@
+from backend.simulation import (
+    EngineRequest,
+    ReceptorEngagement,
+    SimulationEngine,
+)
+
+
+def test_engine_chronic_ssri_profile():
+    engine = SimulationEngine(time_step=6.0)
+    request = EngineRequest(
+        receptors={
+            "HTR1A": ReceptorEngagement(
+                name="HTR1A",
+                occupancy=0.7,
+                mechanism="agonist",
+                kg_weight=0.8,
+                evidence=0.75,
+            ),
+            "HTR2A": ReceptorEngagement(
+                name="HTR2A",
+                occupancy=0.4,
+                mechanism="antagonist",
+                kg_weight=0.6,
+                evidence=0.7,
+            ),
+        },
+        regimen="chronic",
+        adhd=False,
+        gut_bias=True,
+        pvt_weight=0.2,
+    )
+
+    result = engine.run(request)
+
+    assert result.timepoints[-1] >= 168.0
+    assert "DriveInvigoration" in result.scores
+    assert len(result.timepoints) == len(result.trajectories["plasma_concentration"])
+    assert 0.0 <= result.confidence["DriveInvigoration"] <= 1.0
+    assert result.scores["ApathyBlunting"] >= 0.0


### PR DESCRIPTION
## Summary
- add a modular `backend/simulation` package for molecular cascades, PK/PD, and circuit coupling with an orchestration engine
- refactor the `/simulate` endpoint to drive the new engine, expose regimen toggles, and return confidence metrics
- extend backend tests and docs to cover chronic SSRI scenarios and document optional external toolchains

## Testing
- python -m compileall backend/main.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ce6fb7bc7883298272d1b76304b9cb