### PR TITLE
Add API schemas, routes, and integration tests

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,0 +1,5 @@
+"""API package exposing FastAPI routers and schemas."""
+
+from .routes import api_router, get_graph_service, get_simulation_engine
+
+__all__ = ["api_router", "get_graph_service", "get_simulation_engine"]

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -1,0 +1,304 @@
+"""FastAPI route declarations for the Neuropharm Simulation API."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..graph.models import Edge, Evidence, Node
+from ..graph.service import GraphService
+from ..engine.simulator import SimulationEngine, SimulationError
+from .schemas import (
+    Citation,
+    EvidenceEdge,
+    EvidenceRecord,
+    EvidenceSearchRequest,
+    EvidenceSearchResponse,
+    EvidenceSearchResult,
+    ExplainRequest,
+    ExplainResponse,
+    Explanation,
+    GapDescriptor,
+    GapsRequest,
+    GapsResponse,
+    GraphEdge,
+    GraphExpandRequest,
+    GraphExpandResponse,
+    GraphNode,
+    Pagination,
+    PredictEffectsRequest,
+    PredictEffectsResponse,
+    PredictedEffect,
+    Provenance,
+    SimulationRequest,
+    SimulationResponse,
+)
+
+api_router = APIRouter()
+
+_graph_service = GraphService()
+_simulation_engine = SimulationEngine()
+
+
+def get_graph_service() -> GraphService:
+    """Return the singleton GraphService used by the API layer."""
+
+    return _graph_service
+
+
+def get_simulation_engine() -> SimulationEngine:
+    """Return the simulation engine instance."""
+
+    return _simulation_engine
+
+
+def _build_provenance(source: str, notes: str | None = None) -> Provenance:
+    return Provenance(source=source, notes=notes)
+
+
+def _convert_evidence(items: Iterable[Evidence]) -> List[EvidenceRecord]:
+    return [
+        EvidenceRecord(
+            source=item.source,
+            reference=item.reference,
+            confidence=item.confidence,
+            uncertainty=item.uncertainty,
+            annotations=dict(item.annotations),
+        )
+        for item in items
+    ]
+
+
+def _convert_edge(edge: Edge, evidence: List[EvidenceRecord]) -> EvidenceEdge:
+    return EvidenceEdge(
+        subject=edge.subject,
+        predicate=edge.predicate,
+        object=edge.object,
+        relation=edge.relation,
+        knowledge_level=edge.knowledge_level,
+        confidence=edge.confidence,
+        qualifiers=dict(edge.qualifiers),
+        evidence=evidence,
+    )
+
+
+def _convert_node(node: Node) -> GraphNode:
+    return GraphNode(
+        id=node.id,
+        name=node.name,
+        category=node.category,
+        description=node.description,
+        provided_by=node.provided_by,
+        synonyms=list(node.synonyms),
+        xrefs=list(node.xrefs),
+        attributes=dict(node.attributes),
+    )
+
+
+def _convert_graph_edge(edge: Edge) -> GraphEdge:
+    return GraphEdge(
+        subject=edge.subject,
+        predicate=edge.predicate,
+        object=edge.object,
+        relation=edge.relation,
+        qualifiers=dict(edge.qualifiers),
+    )
+
+
+@api_router.post("/evidence/search", response_model=EvidenceSearchResponse, tags=["Evidence"])
+def search_evidence(
+    request: EvidenceSearchRequest,
+    service: GraphService = Depends(get_graph_service),
+) -> EvidenceSearchResponse:
+    filters = request.filters
+    predicate = filters.predicate.value if filters.predicate else None
+    summaries = service.get_evidence(
+        subject=filters.subject,
+        predicate=predicate,
+        object_=filters.object_,
+    )
+
+    results: List[EvidenceSearchResult] = []
+    for summary in summaries:
+        filtered = []
+        for ev in summary.evidence:
+            if filters.source and ev.source.lower() != filters.source.lower():
+                continue
+            if filters.min_confidence is not None:
+                if ev.confidence is None or ev.confidence < filters.min_confidence:
+                    continue
+            filtered.append(ev)
+        if not filtered:
+            continue
+        evidence_models = _convert_evidence(filtered)
+        edge_model = _convert_edge(summary.edge, evidence_models)
+        results.append(
+            EvidenceSearchResult(
+                edge=edge_model,
+                total_evidence=len(evidence_models),
+            )
+        )
+
+    total = len(results)
+    page = request.pagination.page
+    size = request.pagination.size
+    start = (page - 1) * size
+    end = start + size
+    paged_results = results[start:end]
+
+    return EvidenceSearchResponse(
+        results=paged_results,
+        pagination=Pagination(page=page, size=size),
+        filters=filters,
+        provenance=_build_provenance("graph-service", "Evidence search via GraphService.get_evidence"),
+        total=total,
+    )
+
+
+@api_router.post("/graph/expand", response_model=GraphExpandResponse, tags=["Graph"])
+def expand_graph(
+    request: GraphExpandRequest,
+    service: GraphService = Depends(get_graph_service),
+) -> GraphExpandResponse:
+    fragment = service.expand(request.node_id, depth=request.depth, limit=request.limit)
+    nodes = [_convert_node(node) for node in fragment.nodes]
+
+    if request.category_filter:
+        allowed = set(request.category_filter)
+        nodes = [node for node in nodes if node.category in allowed]
+
+    node_ids = {node.id for node in nodes}
+    edges = []
+    for edge in fragment.edges:
+        if node_ids and (edge.subject not in node_ids or edge.object not in node_ids):
+            continue
+        edges.append(_convert_graph_edge(edge))
+
+    return GraphExpandResponse(
+        nodes=nodes[: request.limit],
+        edges=edges[: request.limit * 2],
+        provenance=_build_provenance("graph-service", "Graph expansion performed using GraphService.neighbors"),
+        pagination=Pagination(page=1, size=min(request.limit, max(len(nodes), 1))),
+    )
+
+
+@api_router.post("/predict/effects", response_model=PredictEffectsResponse, tags=["Simulation"])
+def predict_effects(
+    request: PredictEffectsRequest,
+    engine: SimulationEngine = Depends(get_simulation_engine),
+) -> PredictEffectsResponse:
+    sim = request.simulation
+    sim_payload = sim.model_dump()
+    try:
+        result = engine.run(
+            sim_payload["receptors"],
+            acute_1a=sim_payload["acute_1a"],
+            adhd=sim_payload["adhd"],
+            gut_bias=sim_payload["gut_bias"],
+            pvt_weight=sim_payload["pvt_weight"],
+        )
+    except SimulationError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    sorted_scores = sorted(result.scores.items(), key=lambda item: item[1], reverse=True)
+    predicted: List[PredictedEffect] = []
+    for metric, score in sorted_scores[: request.top_n]:
+        rationale_segments: List[str] = []
+        for receptor, refs in result.citations.items():
+            if refs:
+                rationale_segments.append(f"{receptor}: {len(refs)} refs")
+        rationale = "; ".join(rationale_segments) or "No supporting citations available."
+        predicted.append(PredictedEffect(metric=metric, score=score, rationale=rationale))
+
+    return PredictEffectsResponse(
+        compound_id=request.compound_id,
+        requested=request,
+        predicted_effects=predicted,
+        provenance=_build_provenance("simulation-engine", "Derived from simulation score ranking."),
+    )
+
+
+@api_router.post("/simulate", response_model=SimulationResponse, tags=["Simulation"])
+def run_simulation(
+    request: SimulationRequest,
+    engine: SimulationEngine = Depends(get_simulation_engine),
+) -> SimulationResponse:
+    payload = request.model_dump()
+    try:
+        result = engine.run(
+            payload["receptors"],
+            acute_1a=payload["acute_1a"],
+            adhd=payload["adhd"],
+            gut_bias=payload["gut_bias"],
+            pvt_weight=payload["pvt_weight"],
+        )
+    except SimulationError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    citations = {
+        receptor: [Citation(**ref) for ref in refs]
+        for receptor, refs in result.citations.items()
+    }
+
+    return SimulationResponse(
+        scores=result.scores,
+        details=result.details,
+        citations=citations,
+        provenance=_build_provenance("simulation-engine", "Outputs produced by the Neuropharm simulation engine."),
+    )
+
+
+@api_router.post("/explain", response_model=ExplainResponse, tags=["Evidence"])
+def explain_relationship(
+    request: ExplainRequest,
+    service: GraphService = Depends(get_graph_service),
+) -> ExplainResponse:
+    predicate = request.predicate.value if request.predicate else None
+    summaries = service.get_evidence(
+        subject=request.subject,
+        predicate=predicate,
+        object_=request.object_,
+    )
+    explanations: List[Explanation] = []
+    for summary in summaries:
+        evidence = _convert_evidence(summary.evidence[: request.max_evidence])
+        if not evidence:
+            continue
+        explanations.append(
+            Explanation(
+                subject=summary.edge.subject,
+                predicate=summary.edge.predicate,
+                object=summary.edge.object,
+                evidence=evidence,
+            )
+        )
+
+    return ExplainResponse(
+        explanations=explanations,
+        provenance=_build_provenance("graph-service", "Explanation synthesised from direct evidence."),
+    )
+
+
+@api_router.post("/gaps", response_model=GapsResponse, tags=["Graph"])
+def find_gaps(
+    request: GapsRequest,
+    service: GraphService = Depends(get_graph_service),
+) -> GapsResponse:
+    gaps = service.find_gaps(request.focus_nodes)
+    descriptors = [
+        GapDescriptor(subject=gap.subject, object=gap.object, reason=gap.reason)
+        for gap in gaps
+    ]
+    return GapsResponse(
+        gaps=descriptors,
+        provenance=_build_provenance("graph-service", "Gap analysis across provided focus nodes."),
+        total=len(descriptors),
+    )
+
+
+__all__ = [
+    "api_router",
+    "get_graph_service",
+    "get_simulation_engine",
+]

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -1,0 +1,282 @@
+"""Pydantic request and response models for the public API."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, Optional
+
+from pydantic import BaseModel, Field, ConfigDict
+
+from ..graph.models import BiolinkEntity, BiolinkPredicate
+
+Mechanism = str
+
+
+class Provenance(BaseModel):
+    """Metadata describing how a response was assembled."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    source: str = Field(..., description="System that produced the payload.")
+    notes: Optional[str] = Field(default=None, description="Optional explanation of processing steps.")
+
+
+class Pagination(BaseModel):
+    """Pagination controls shared by multiple endpoints."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    page: int = Field(default=1, ge=1)
+    size: int = Field(default=25, ge=1, le=100)
+
+
+class EvidenceFilters(BaseModel):
+    """Filters that can be applied to the evidence search endpoint."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    subject: Optional[str] = Field(default=None, description="CURIE identifier for the subject node.")
+    predicate: Optional[BiolinkPredicate] = Field(default=None)
+    object_: Optional[str] = Field(default=None, alias="object", description="CURIE identifier for the object node.")
+    source: Optional[str] = Field(default=None, description="Evidence source label (e.g. INDRA).")
+    min_confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+
+
+class EvidenceRecord(BaseModel):
+    """Individual piece of evidence supporting a graph edge."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    reference: Optional[str] = None
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    uncertainty: Optional[str] = None
+    annotations: Dict[str, Any] = Field(default_factory=dict)
+
+
+class EvidenceEdge(BaseModel):
+    """Serialised edge representation returned by the API."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    subject: str
+    predicate: BiolinkPredicate
+    object_: str = Field(alias="object")
+    relation: Optional[str] = None
+    knowledge_level: Optional[str] = None
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    qualifiers: Dict[str, Any] = Field(default_factory=dict)
+    evidence: List[EvidenceRecord] = Field(default_factory=list)
+
+
+class EvidenceSearchResult(BaseModel):
+    """Container bundling an edge with summary statistics."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    edge: EvidenceEdge
+    total_evidence: int
+
+
+class EvidenceSearchRequest(BaseModel):
+    """Payload used to query the evidence catalogue."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    filters: EvidenceFilters = Field(default_factory=EvidenceFilters)
+    pagination: Pagination = Field(default_factory=Pagination)
+
+
+class EvidenceSearchResponse(BaseModel):
+    """Response returned for evidence search queries."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    results: List[EvidenceSearchResult]
+    pagination: Pagination
+    filters: EvidenceFilters
+    provenance: Provenance
+    total: int
+
+
+class GraphNode(BaseModel):
+    """Graph node representation for expansion responses."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: Optional[str] = None
+    category: Optional[BiolinkEntity] = None
+    description: Optional[str] = None
+    provided_by: Optional[str] = None
+    synonyms: List[str] = Field(default_factory=list)
+    xrefs: List[str] = Field(default_factory=list)
+    attributes: Dict[str, Any] = Field(default_factory=dict)
+
+
+class GraphEdge(BaseModel):
+    """Edge representation for expansion responses."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    subject: str
+    predicate: BiolinkPredicate
+    object_: str = Field(alias="object")
+    relation: Optional[str] = None
+    qualifiers: Dict[str, Any] = Field(default_factory=dict)
+
+
+class GraphExpandRequest(BaseModel):
+    """Request payload for `/graph/expand`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: str = Field(..., description="Seed node identifier to expand around.")
+    depth: int = Field(default=1, ge=1, le=5)
+    limit: int = Field(default=25, ge=1, le=200)
+    category_filter: Optional[List[BiolinkEntity]] = Field(default=None, description="Restrict nodes to these categories.")
+
+
+class GraphExpandResponse(BaseModel):
+    """Response returned by `/graph/expand`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    nodes: List[GraphNode]
+    edges: List[GraphEdge]
+    provenance: Provenance
+    pagination: Pagination
+
+
+class ReceptorSetting(BaseModel):
+    """Input specification for a single receptor."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    occ: float = Field(ge=0.0, le=1.0)
+    mech: Mechanism
+
+
+class SimulationRequest(BaseModel):
+    """Payload supplied to the simulation engine."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    receptors: Dict[str, ReceptorSetting] = Field(default_factory=dict)
+    acute_1a: bool = False
+    adhd: bool = False
+    gut_bias: bool = False
+    pvt_weight: float = Field(default=0.5, ge=0.0, le=1.0)
+
+
+class Citation(BaseModel):
+    """Literature citation supporting simulated mechanisms."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    pmid: Optional[str] = None
+    doi: Optional[str] = None
+
+
+class SimulationResponse(BaseModel):
+    """Standard response envelope for the simulation endpoint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scores: Dict[str, float]
+    details: Dict[str, Any]
+    citations: Dict[str, List[Citation]]
+    provenance: Provenance
+
+
+class PredictEffectsRequest(BaseModel):
+    """Request body for `/predict/effects`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    compound_id: str
+    simulation: SimulationRequest
+    hypothesis: Optional[str] = Field(default=None, description="Optional description of the experimental context.")
+    top_n: int = Field(default=3, ge=1, le=6)
+
+
+class PredictedEffect(BaseModel):
+    """Single predicted effect returned by the prediction endpoint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    metric: str
+    score: float
+    rationale: str
+
+
+class PredictEffectsResponse(BaseModel):
+    """Response structure for `/predict/effects`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    compound_id: str
+    requested: PredictEffectsRequest
+    predicted_effects: List[PredictedEffect]
+    provenance: Provenance
+
+
+class ExplainRequest(BaseModel):
+    """Request payload for `/explain`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    subject: str
+    object_: str = Field(alias="object")
+    predicate: Optional[BiolinkPredicate] = None
+    max_evidence: int = Field(default=5, ge=1, le=25)
+
+
+class Explanation(BaseModel):
+    """Explanation of a relationship derived from the knowledge graph."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    subject: str
+    predicate: BiolinkPredicate
+    object_: str = Field(alias="object")
+    evidence: List[EvidenceRecord]
+
+
+class ExplainResponse(BaseModel):
+    """Response returned by the explanation endpoint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    explanations: List[Explanation]
+    provenance: Provenance
+
+
+class GapsRequest(BaseModel):
+    """Request payload for `/gaps`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    focus_nodes: List[str] = Field(..., min_length=2, max_length=50)
+
+
+class GapDescriptor(BaseModel):
+    """Description of a detected knowledge gap."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    subject: str
+    object_: str = Field(alias="object")
+    reason: str
+
+
+class GapsResponse(BaseModel):
+    """Response returned by `/gaps`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    gaps: List[GapDescriptor]
+    provenance: Provenance
+    total: int

--- a/backend/engine/simulator.py
+++ b/backend/engine/simulator.py
@@ -1,0 +1,134 @@
+"""Simulation engine for the Neuropharm Simulation Lab API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+from .receptors import (
+    RECEPTORS,
+    canonical_receptor_name,
+    get_mechanism_factor,
+    get_receptor_weights,
+)
+
+
+class SimulationError(Exception):
+    """Raised when the simulation engine cannot evaluate a payload."""
+
+
+@dataclass(slots=True)
+class SimulationResult:
+    """Container for simulation outputs returned by the engine."""
+
+    scores: Dict[str, float]
+    details: Dict[str, Any]
+    citations: Dict[str, list[Dict[str, str]]]
+
+
+class SimulationEngine:
+    """Encapsulates the scoring logic used by `/simulate` and related routes."""
+
+    METRICS = (
+        "drive",
+        "apathy",
+        "motivation",
+        "cognitive_flexibility",
+        "anxiety",
+        "sleep_quality",
+    )
+
+    def __init__(self, receptor_refs: Mapping[str, list[dict[str, str]]] | None = None) -> None:
+        self._receptor_refs = dict(receptor_refs or self._load_refs())
+
+    @staticmethod
+    def _load_refs() -> Mapping[str, list[dict[str, str]]]:
+        refs_path = Path(__file__).resolve().parent.parent / "refs.json"
+        if not refs_path.exists():
+            return {}
+        with refs_path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        if not isinstance(data, Mapping):  # pragma: no cover - defensive
+            return {}
+        return data  # type: ignore[return-value]
+
+    def run(
+        self,
+        receptors: Mapping[str, Mapping[str, Any]] | None = None,
+        *,
+        acute_1a: bool = False,
+        adhd: bool = False,
+        gut_bias: bool = False,
+        pvt_weight: float = 0.5,
+    ) -> SimulationResult:
+        """Execute the simulation for a given receptor configuration."""
+
+        receptors = receptors or {}
+        contributions: Dict[str, float] = {metric: 0.0 for metric in self.METRICS}
+
+        for receptor_name, spec in receptors.items():
+            canon = canonical_receptor_name(receptor_name)
+            if canon not in RECEPTORS:
+                continue
+            try:
+                weights = get_receptor_weights(canon)
+            except KeyError as exc:  # pragma: no cover - defensive
+                raise SimulationError(f"Unknown receptor '{canon}'") from exc
+            mechanism = spec.get("mech")
+            occupancy = spec.get("occ", 0.0)
+            try:
+                factor = get_mechanism_factor(str(mechanism))
+            except ValueError as exc:
+                raise SimulationError(str(exc)) from exc
+            for metric, weight in weights.items():
+                contributions[metric] += weight * float(occupancy) * factor
+
+        if adhd:
+            contributions["drive"] -= 0.3
+            contributions["motivation"] -= 0.2
+        if gut_bias:
+            for metric in contributions:
+                if contributions[metric] < 0:
+                    contributions[metric] *= 0.9
+        if acute_1a:
+            for metric in contributions:
+                contributions[metric] *= 0.75
+
+        scale = 1.0 - (float(pvt_weight) * 0.2)
+        for metric in contributions:
+            contributions[metric] *= scale
+
+        scores: Dict[str, float] = {}
+        for metric, value in contributions.items():
+            baseline = 50.0
+            change = 20.0 * value
+            score = baseline + change
+            if metric == "apathy":
+                score = 100.0 - score
+            name_map = {
+                "drive": "DriveInvigoration",
+                "apathy": "ApathyBlunting",
+                "motivation": "Motivation",
+                "cognitive_flexibility": "CognitiveFlexibility",
+                "anxiety": "Anxiety",
+                "sleep_quality": "SleepQuality",
+            }
+            scores[name_map[metric]] = max(0.0, min(100.0, score))
+
+        citations: Dict[str, list[Dict[str, str]]] = {}
+        for receptor_name in receptors:
+            canon = canonical_receptor_name(receptor_name)
+            refs = self._receptor_refs.get(canon)
+            if refs:
+                citations[canon] = [dict(ref) for ref in refs]
+
+        details: Dict[str, Any] = {
+            "raw_contributions": dict(contributions),
+            "final_scores": dict(scores),
+        }
+        return SimulationResult(scores=scores, details=details, citations=citations)
+
+
+__all__ = ["SimulationEngine", "SimulationError", "SimulationResult"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,108 +1,41 @@
-"""
-FastAPI backend for the neuropharm simulation lab.
+"""FastAPI application entrypoint for the Neuropharm Simulation Lab."""
 
-This service exposes a `/simulate` endpoint that accepts a JSON
-payload describing the current receptor occupancy, acute/chronic flags,
-phenotype modifiers (such as ADHD), gut-bias toggles, and other
-parameters. It returns computed scores for motivational drive, apathy
-blunting, and other high‑level readouts.  The current implementation
-provides a simple placeholder model to demonstrate the API and wiring;
-future work should extend this file with a full mechanistic model of
-serotonin, dopamine, glutamate, histamine, and other systems across
-brain regions.
+from __future__ import annotations
 
-The API also exposes a root `/` endpoint for a basic health check.
-"""
-
-from fastapi import FastAPI, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
-from typing import Any, Dict, Literal
-
-import json
 import os
-from pathlib import Path
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
-from .engine.receptors import (
-    RECEPTORS,
-    canonical_receptor_name,
-    get_mechanism_factor,
-    get_receptor_weights,
+from .api.routes import api_router
+
+DESCRIPTION = (
+    "Explore neuromodulator dynamics and curated literature support via a "
+    "unified API. Simulation endpoints expose the Neuropharm receptor "
+    "occupancy model, while graph utilities surface evidence from the "
+    "knowledge graph assembled from INDRA, OpenAlex, ChEMBL, and atlas "
+    "resources."
 )
 
+app = FastAPI(
+    title="Neuropharm Simulation API",
+    description=DESCRIPTION,
+    version="0.2.0",
+    contact={
+        "name": "Neuropharm Simulation Lab",
+        "url": "https://github.com/darkfrostx-cmd/neuropharm-sim-lab",
+        "email": "neuropharm-sim-lab@example.com",
+    },
+    license_info={
+        "name": "MIT License",
+        "url": "https://opensource.org/licenses/MIT",
+    },
+    openapi_tags=[
+        {"name": "Simulation", "description": "Run receptor-based simulations and effect predictions."},
+        {"name": "Evidence", "description": "Search and explain curated literature evidence."},
+        {"name": "Graph", "description": "Explore the knowledge graph topology and gaps."},
+    ],
+)
 
-Mechanism = Literal["agonist", "antagonist", "partial", "inverse"]
-
-
-REFS_PATH = Path(__file__).with_name("refs.json")
-try:
-    with REFS_PATH.open("r", encoding="utf-8") as f:
-        RECEPTOR_REFS: dict[str, list[dict[str, str]]] = json.load(f)
-except FileNotFoundError:
-    RECEPTOR_REFS = {}
-
-# -----------------------------------------------------------------------------
-# Pydantic models
-# -----------------------------------------------------------------------------
-
-class ReceptorSpec(BaseModel):
-    """Specification for a single receptor.
-
-    Attributes
-    ----------
-    occ : float
-        Fractional occupancy of the receptor (0.0–1.0).
-    mech : str
-        Mechanism of the ligand ("agonist", "antagonist", "partial", or
-        "inverse").  Future versions may support additional values.
-    """
-    occ: float = Field(ge=0.0, le=1.0)
-    mech: Mechanism
-
-
-class SimulationInput(BaseModel):
-    """Input payload for the simulation.
-
-    Fields are deliberately flexible to allow future extensions
-    (additional neurotransmitters, receptor subtypes, etc.).
-    """
-    receptors: Dict[str, ReceptorSpec]
-    acute_1a: bool = False
-    adhd: bool = False
-    gut_bias: bool = False
-    pvt_weight: float = 0.5
-
-
-class Citation(BaseModel):
-    """Reference supporting a mechanism or receptor effect."""
-
-    title: str
-    pmid: str
-    doi: str
-
-
-class SimulationOutput(BaseModel):
-    """Return format from the simulation engine.
-
-    `scores` contains high‑level behavioural metrics normalised to 0–100.
-    `details` includes intermediate values (e.g. computed dopamine phasic
-    drive) that may be useful for debugging or future UI visualisations.
-    `citations` returns a list of PubMed IDs and/or DOIs supporting the
-    mechanisms involved in generating the result.
-    """
-    scores: Dict[str, float]
-    details: Dict[str, Any]
-    citations: Dict[str, list[Citation]]
-
-
-# -----------------------------------------------------------------------------
-# Application
-# -----------------------------------------------------------------------------
-
-app = FastAPI(title="Neuropharm Simulation API",
-              description=("Simulate serotonergic, dopaminergic and other\n                           neurotransmitter systems under a variety of\n                           receptor manipulations.  See the README for\n                           details on the expected payload format."))
-
-# Configure CORS
 origins = os.environ.get("CORS_ORIGINS", "https://darkfrostx-cmd.github.io").split(",")
 app.add_middleware(
     CORSMiddleware,
@@ -114,121 +47,17 @@ app.add_middleware(
 
 
 @app.get("/")
-def read_root():
-    """Health check endpoint.
+def read_root() -> dict[str, str]:
+    """Root health-check endpoint."""
 
-    Returns a basic status message so that clients can confirm the API is
-    running.
-    """
-    return {"status": "ok", "version": "2025.09.05"}
-
+    return {"status": "ok", "version": app.version}
 
 
 @app.get("/health")
-def health():
-    return {"status": "ok", "version": "2025.09.05"}
+def health() -> dict[str, str]:
+    """Secondary health endpoint for monitoring systems."""
 
-@app.post("/simulate", response_model=SimulationOutput)
-def simulate(inp: SimulationInput) -> SimulationOutput:
-    """Run a single simulation with the provided input.
+    return {"status": "ok", "version": app.version}
 
-    This function currently implements a highly simplified scoring
-    algorithm. It computes phasic dopamine drive based on 5‑HT2C and
-    5‑HT1B occupancy, modulates it with ADHD state and gut-bias flags,
-    and then maps the result into overall "Drive" and "Apathy" scores.
 
-  
-Parameters
-    ----------
-    inp : SimulationInput
-        The payload specifying receptor occupancies and modifiers.
-
-    Returns
-    -------
-    SimulationOutput
-        A dictionary containing high‑level scores, intermediate details
-        and citations underpinning the mechanisms used.
-    """
-
-    # Initialise metric contributions.  Baseline of 50 for each metric.
-    metrics = [
-        "drive",
-        "apathy",
-        "motivation",
-        "cognitive_flexibility",
-        "anxiety",
-        "sleep_quality",
-    ]
-    contrib: Dict[str, float] = {m: 0.0 for m in metrics}
-
-    # Accumulate contributions from each receptor in the input.  For
-    # unknown receptors, silently ignore.  Mechanism factor scales the
-    # per‑unit weight; occupancy scales the contribution.
-    for rec_name, spec in inp.receptors.items():
-        canon = canonical_receptor_name(rec_name)
-        if canon not in RECEPTORS:
-            continue
-        weights = get_receptor_weights(canon)
-        try:
-            factor = get_mechanism_factor(spec.mech)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        for m, w in weights.items():
-            contrib[m] += w * spec.occ * factor
-
-    # Apply phenotype modifiers.  ADHD reduces baseline tone for drive
-    # and motivation; gut_bias attenuates negative contributions (makes
-    # apathy less severe and drive more preserved); acute_1a lowers
-    # overall serotonergic effect (scale contributions down).
-    if inp.adhd:
-        contrib["drive"] -= 0.3
-        contrib["motivation"] -= 0.2
-    if inp.gut_bias:
-        for m in metrics:
-            # If contribution is negative, reduce its magnitude by 10%
-            if contrib[m] < 0:
-                contrib[m] *= 0.9
-    if inp.acute_1a:
-        for m in metrics:
-            contrib[m] *= 0.75
-    # PVT gating weight scales contributions from 5-HT1B (if present);
-    # approximate by scaling global contributions by (1 - pvt_weight*0.2)
-    contrib_scale = 1.0 - (inp.pvt_weight * 0.2)
-    for m in metrics:
-        contrib[m] *= contrib_scale
-
-    # Convert contributions to scores.  Baseline is 50; each unit of
-    # contribution moves the score by 20 points.  Clamp between 0 and
-    # 100.  Note: for apathy, higher contribution increases apathy; for
-    # other metrics, contributions add directly.
-    scores: Dict[str, float] = {}
-    for m in metrics:
-        base = 50.0
-        change = 20.0 * contrib[m]
-        val = base + change
-        # Invert apathy into ApathyBlunting (higher apathy = lower score)
-        if m == "apathy":
-            val = 100.0 - val
-        scores_name = {
-            "drive": "DriveInvigoration",
-            "apathy": "ApathyBlunting",
-            "motivation": "Motivation",
-            "cognitive_flexibility": "CognitiveFlexibility",
-            "anxiety": "Anxiety",
-            "sleep_quality": "SleepQuality",
-        }[m]
-        scores[scores_name] = max(0.0, min(100.0, val))
-
-    # Build citations dictionary: gather references for each receptor used.
-    citations: Dict[str, list[Citation]] = {}
-    for rec_name in inp.receptors.keys():
-        canon = canonical_receptor_name(rec_name)
-        if canon in RECEPTOR_REFS:
-            citations[canon] = [Citation(**ref) for ref in RECEPTOR_REFS[canon]]
-
-    details = {
-        "raw_contributions": contrib,
-        "final_scores": scores,
-    }
-
-    return SimulationOutput(scores=scores, details=details, citations=citations)
+app.include_router(api_router)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.22.0
 scipy>=1.8.0
 pydantic>=2.1.1
 requests>=2.31.0
+httpx>=0.27.0

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -1,0 +1,188 @@
+"""Integration tests for the FastAPI routes using httpx."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend.main import app
+from backend.api.routes import get_graph_service, get_simulation_engine
+from backend.engine.simulator import SimulationEngine
+from backend.graph.models import BiolinkEntity, BiolinkPredicate, Edge, Evidence, Node
+from backend.graph.persistence import InMemoryGraphStore
+from backend.graph.service import GraphService
+
+
+@pytest.fixture()
+def anyio_backend() -> str:  # pragma: no cover - restrict to asyncio for anyio plugin
+    return "asyncio"
+
+
+@pytest.fixture()
+def graph_service_fixture() -> GraphService:
+    store = InMemoryGraphStore()
+    service = GraphService(store=store)
+
+    nodes = [
+        Node(id="HGNC:5", name="SLC6A4", category=BiolinkEntity.GENE),
+        Node(id="CHEMBL:25", name="Sertraline", category=BiolinkEntity.CHEMICAL_SUBSTANCE),
+        Node(id="HGNC:6", name="MAOA", category=BiolinkEntity.GENE),
+    ]
+
+    edges = [
+        Edge(
+            subject="HGNC:5",
+            predicate=BiolinkPredicate.AFFECTS,
+            object="CHEMBL:25",
+            relation="biolink:affects",
+            knowledge_level="supported by literature",
+            evidence=[
+                Evidence(source="INDRA", reference="PMID:123", confidence=0.8, annotations={"statement": "Example"}),
+                Evidence(source="ChEMBL", reference="CHEMBL:XYZ", confidence=0.6, annotations={"assay": "IC50"}),
+            ],
+        ),
+        Edge(
+            subject="HGNC:6",
+            predicate=BiolinkPredicate.RELATED_TO,
+            object="CHEMBL:25",
+            relation="biolink:related_to",
+            knowledge_level="observed",
+            evidence=[Evidence(source="OpenAlex", reference="10.1000/example", confidence=0.7)],
+        ),
+    ]
+
+    service.persist(nodes, edges)
+    return service
+
+
+@pytest.fixture()
+async def test_client(graph_service_fixture: GraphService):
+    app.dependency_overrides[get_graph_service] = lambda: graph_service_fixture
+    app.dependency_overrides[get_simulation_engine] = SimulationEngine
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_evidence_search_returns_filtered_results(test_client: AsyncClient) -> None:
+    payload = {
+        "filters": {"subject": "HGNC:5", "source": "INDRA"},
+        "pagination": {"page": 1, "size": 10},
+    }
+    response = await test_client.post("/evidence/search", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["results"][0]["edge"]["subject"] == "HGNC:5"
+    assert data["results"][0]["total_evidence"] == 1
+
+
+@pytest.mark.anyio("asyncio")
+async def test_evidence_search_with_unknown_source(test_client: AsyncClient) -> None:
+    payload = {
+        "filters": {"subject": "HGNC:5", "source": "NON_EXISTENT"},
+        "pagination": {"page": 1, "size": 10},
+    }
+    response = await test_client.post("/evidence/search", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 0
+    assert data["results"] == []
+
+
+@pytest.mark.anyio("asyncio")
+async def test_graph_expand_supports_category_filters(test_client: AsyncClient) -> None:
+    payload = {
+        "node_id": "CHEMBL:25",
+        "depth": 1,
+        "limit": 10,
+        "category_filter": [BiolinkEntity.CHEMICAL_SUBSTANCE.value],
+    }
+    response = await test_client.post("/graph/expand", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["nodes"]) == 1
+    assert data["nodes"][0]["id"] == "CHEMBL:25"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_predict_effects_returns_top_scores(test_client: AsyncClient) -> None:
+    payload = {
+        "compound_id": "CHEMBL:25",
+        "simulation": {
+            "receptors": {"5-HT2C": {"occ": 0.5, "mech": "antagonist"}},
+            "acute_1a": False,
+            "adhd": False,
+            "gut_bias": False,
+            "pvt_weight": 0.2,
+        },
+        "top_n": 2,
+    }
+    response = await test_client.post("/predict/effects", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["predicted_effects"]) == 2
+    assert {effect["metric"] for effect in data["predicted_effects"]}
+
+
+@pytest.mark.anyio("asyncio")
+async def test_predict_effects_invalid_mechanism_returns_error(test_client: AsyncClient) -> None:
+    payload = {
+        "compound_id": "CHEMBL:25",
+        "simulation": {
+            "receptors": {"5-HT2C": {"occ": 0.5, "mech": "unknown"}},
+        },
+        "top_n": 1,
+    }
+    response = await test_client.post("/predict/effects", json=payload)
+    assert response.status_code == 400
+
+
+@pytest.mark.anyio("asyncio")
+async def test_simulate_returns_scores_and_citations(test_client: AsyncClient) -> None:
+    payload = {
+        "receptors": {"5-HT2C": {"occ": 0.5, "mech": "antagonist"}},
+        "adhd": True,
+    }
+    response = await test_client.post("/simulate", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "DriveInvigoration" in data["scores"]
+    assert "provenance" in data
+
+
+@pytest.mark.anyio("asyncio")
+async def test_explain_limits_evidence(test_client: AsyncClient) -> None:
+    payload = {
+        "subject": "HGNC:5",
+        "object": "CHEMBL:25",
+        "predicate": BiolinkPredicate.AFFECTS.value,
+        "max_evidence": 1,
+    }
+    response = await test_client.post("/explain", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["explanations"]) == 1
+    assert len(data["explanations"][0]["evidence"]) == 1
+
+
+@pytest.mark.anyio("asyncio")
+async def test_gaps_endpoint_identifies_missing_connections(test_client: AsyncClient) -> None:
+    payload = {"focus_nodes": ["HGNC:5", "HGNC:6", "CHEMBL:25"]}
+    response = await test_client.post("/gaps", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] >= 1
+    assert all("reason" in gap for gap in data["gaps"])
+
+
+@pytest.mark.anyio("asyncio")
+async def test_invalid_pagination_rejected(test_client: AsyncClient) -> None:
+    payload = {
+        "filters": {"subject": "HGNC:5"},
+        "pagination": {"page": 1, "size": 500},
+    }
+    response = await test_client.post("/evidence/search", json=payload)
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add dedicated Pydantic schemas for evidence, graph, simulation, prediction, and explanation payloads
- implement API router that delegates to the graph service and simulation engine with pagination, filtering, and provenance
- wire the router into the FastAPI app with enriched metadata and add httpx-powered integration tests

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce6fba0cc08329bcb666b8c729d78d