### PR TITLE
Leverage knowledge graph evidence in receptor simulation

### DIFF
--- a/backend/simulation/__init__.py
+++ b/backend/simulation/__init__.py
@@ -6,6 +6,7 @@ from .engine import (
     ReceptorEngagement,
     SimulationEngine,
 )
+from .kg_adapter import GraphBackedReceptorAdapter, ReceptorEvidenceBundle
 from .molecular import MolecularCascadeParams, MolecularCascadeResult, simulate_cascade
 from .pkpd import PKPDParameters, PKPDProfile, simulate_pkpd
 from .circuit import CircuitParameters, CircuitResponse, simulate_circuit_response
@@ -15,6 +16,8 @@ __all__ = [
     "EngineResult",
     "ReceptorEngagement",
     "SimulationEngine",
+    "GraphBackedReceptorAdapter",
+    "ReceptorEvidenceBundle",
     "MolecularCascadeParams",
     "MolecularCascadeResult",
     "simulate_cascade",

--- a/backend/simulation/kg_adapter.py
+++ b/backend/simulation/kg_adapter.py
@@ -1,0 +1,289 @@
+"""Adapters that translate knowledge graph evidence into engine inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Dict, List, Sequence
+
+from ..engine.receptors import canonical_receptor_name
+from ..graph.models import BiolinkPredicate, Edge
+from ..graph.service import GraphService
+
+
+@dataclass(frozen=True)
+class ReceptorEvidenceBundle:
+    """Container describing evidence-derived receptor parameters."""
+
+    kg_weight: float
+    evidence_score: float
+    affinity: float | None
+    expression: float | None
+    evidence_sources: tuple[str, ...]
+    evidence_count: int
+
+
+class GraphBackedReceptorAdapter:
+    """Aggregate receptor context from the knowledge graph."""
+
+    def __init__(
+        self,
+        graph_service: GraphService,
+        default_kg_weight: float = 0.25,
+        default_evidence: float = 0.45,
+    ) -> None:
+        self.graph_service = graph_service
+        self.default_kg_weight = default_kg_weight
+        self.default_evidence = default_evidence
+        self._cache: Dict[str, Dict[str, Any]] = {}
+
+    # ------------------------------------------------------------------
+    # Cache management helpers
+    # ------------------------------------------------------------------
+    def clear_cache(self) -> None:
+        """Remove all cached receptor lookups."""
+
+        self._cache.clear()
+
+    def invalidate(self, receptor: str) -> None:
+        """Invalidate cached evidence for a specific receptor."""
+
+        self._cache.pop(canonical_receptor_name(receptor), None)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def derive(
+        self,
+        receptor: str,
+        *,
+        fallback_weight: float | None = None,
+        fallback_evidence: float | None = None,
+    ) -> ReceptorEvidenceBundle:
+        """Return a :class:`ReceptorEvidenceBundle` for ``receptor``.
+
+        Parameters
+        ----------
+        receptor:
+            Name of the receptor using any identifier understood by
+            :func:`canonical_receptor_name`.
+        fallback_weight:
+            Baseline weight used if the knowledge graph lacks interaction
+            data.
+        fallback_evidence:
+            Baseline evidence score when no citations or confidences are
+            available.
+        """
+
+        canon = canonical_receptor_name(receptor)
+        raw = self._cache.get(canon)
+        if raw is None:
+            raw = self._compute_raw_metrics(canon)
+            self._cache[canon] = raw
+        return self._build_bundle(raw, fallback_weight, fallback_evidence)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _build_bundle(
+        self,
+        raw: Dict[str, Any],
+        fallback_weight: float | None,
+        fallback_evidence: float | None,
+    ) -> ReceptorEvidenceBundle:
+        kg_weight = raw["kg_weight"]
+        evidence_score = raw["evidence"]
+
+        baseline_weight = fallback_weight if fallback_weight is not None else self.default_kg_weight
+        baseline_evidence = fallback_evidence if fallback_evidence is not None else self.default_evidence
+
+        if kg_weight is None:
+            kg_weight = baseline_weight
+        if evidence_score is None:
+            evidence_score = baseline_evidence
+
+        kg_weight = float(max(0.05, min(0.95, kg_weight)))
+        evidence_score = float(max(0.05, min(0.99, evidence_score)))
+
+        return ReceptorEvidenceBundle(
+            kg_weight=kg_weight,
+            evidence_score=evidence_score,
+            affinity=raw.get("affinity"),
+            expression=raw.get("expression"),
+            evidence_sources=tuple(raw.get("sources", ())),
+            evidence_count=int(raw.get("evidence_count", 0)),
+        )
+
+    def _compute_raw_metrics(self, canon: str) -> Dict[str, Any]:
+        identifiers = self._candidate_identifiers(canon)
+        edges = self._collect_edges(identifiers)
+
+        affinity_values: List[float] = []
+        expression_values: List[float] = []
+        evidence_values: List[float] = []
+        sources: set[str] = set()
+
+        has_interaction = False
+        has_expression = False
+
+        for edge in edges:
+            predicate = edge.predicate
+            if predicate == BiolinkPredicate.INTERACTS_WITH:
+                has_interaction = True
+            if predicate in {BiolinkPredicate.EXPRESSES, BiolinkPredicate.COEXPRESSION_WITH}:
+                has_expression = True
+
+            self._harvest_from_edge(
+                edge,
+                affinity_values=affinity_values,
+                expression_values=expression_values,
+                evidence_values=evidence_values,
+                sources=sources,
+            )
+
+        affinity = _combine_scores(affinity_values, default=None, scale=6.0)
+        expression = _combine_scores(expression_values, default=None, scale=8.0)
+        evidence_norm = _combine_scores(evidence_values, default=None, scale=5.0)
+
+        if affinity is None and has_interaction:
+            affinity = 0.45
+        if expression is None and has_expression:
+            expression = 0.4
+        if evidence_norm is None and edges:
+            evidence_norm = 0.5
+
+        kg_weight = _combine_kg_weight(affinity, expression, evidence_norm)
+        evidence_score = None
+        if evidence_norm is not None:
+            coverage_bonus = min(0.25, 0.07 * len(sources))
+            evidence_score = float(0.35 + 0.5 * evidence_norm + coverage_bonus)
+
+        return {
+            "affinity": affinity,
+            "expression": expression,
+            "evidence": evidence_score,
+            "kg_weight": kg_weight,
+            "sources": tuple(sorted(sources)),
+            "evidence_count": len(evidence_values),
+        }
+
+    def _candidate_identifiers(self, canon: str) -> Sequence[str]:
+        base = canon.strip()
+        candidates = [base, base.replace("-", ""), base.upper()]
+        compact = base.replace("-", "").upper()
+        if compact.startswith("5HT"):
+            suffix = compact[3:]
+            gene = f"HTR{suffix}"
+            candidates.extend({gene, f"HGNC:{gene}"})
+        return list(dict.fromkeys(filter(None, candidates)))
+
+    def _collect_edges(self, identifiers: Sequence[str]) -> List[Edge]:
+        seen: Dict[tuple[str, str, str], Edge] = {}
+        for identifier in identifiers:
+            for summary in self.graph_service.get_evidence(subject=identifier):
+                seen[summary.edge.key] = summary.edge
+            for summary in self.graph_service.get_evidence(object_=identifier):
+                seen[summary.edge.key] = summary.edge
+        return list(seen.values())
+
+    def _harvest_from_edge(
+        self,
+        edge: Edge,
+        *,
+        affinity_values: List[float],
+        expression_values: List[float],
+        evidence_values: List[float],
+        sources: set[str],
+    ) -> None:
+        predicate = edge.predicate
+        conf_value = _safe_float(edge.confidence)
+        if conf_value is not None:
+            evidence_values.append(conf_value)
+            if predicate == BiolinkPredicate.INTERACTS_WITH:
+                affinity_values.append(conf_value)
+            if predicate in {BiolinkPredicate.EXPRESSES, BiolinkPredicate.COEXPRESSION_WITH}:
+                expression_values.append(conf_value)
+
+        for key in ("affinity", "affinity_nM", "pchembl_value", "weight"):
+            value = _safe_float(edge.qualifiers.get(key))
+            if value is not None:
+                if predicate == BiolinkPredicate.INTERACTS_WITH:
+                    affinity_values.append(value)
+                elif predicate in {BiolinkPredicate.EXPRESSES, BiolinkPredicate.COEXPRESSION_WITH}:
+                    expression_values.append(value)
+                else:
+                    evidence_values.append(value)
+
+        if predicate in {BiolinkPredicate.EXPRESSES, BiolinkPredicate.COEXPRESSION_WITH}:
+            for key in ("expression", "zscore", "tau"):
+                value = _safe_float(edge.qualifiers.get(key))
+                if value is not None:
+                    expression_values.append(value)
+
+        for ev in edge.evidence:
+            if ev.source:
+                sources.add(ev.source)
+            ev_conf = _safe_float(ev.confidence)
+            if ev_conf is not None:
+                evidence_values.append(ev_conf)
+                if predicate == BiolinkPredicate.INTERACTS_WITH:
+                    affinity_values.append(ev_conf)
+                if predicate in {BiolinkPredicate.EXPRESSES, BiolinkPredicate.COEXPRESSION_WITH}:
+                    expression_values.append(ev_conf)
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and math.isnan(value):
+            return None
+        return float(value)
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalise(value: float, *, scale: float) -> float:
+    if value < 0:
+        return 0.0
+    if value > 1.0:
+        return float(1.0 - math.exp(-value / max(scale, 1.0)))
+    return float(max(0.0, min(1.0, value)))
+
+
+def _combine_scores(values: Sequence[float], default: float | None, *, scale: float) -> float | None:
+    cleaned: List[float] = []
+    for raw in values:
+        value = _safe_float(raw)
+        if value is None:
+            continue
+        cleaned.append(_normalise(value, scale=scale))
+    if cleaned:
+        return float(sum(cleaned) / len(cleaned))
+    return default
+
+
+def _combine_kg_weight(
+    affinity: float | None,
+    expression: float | None,
+    evidence: float | None,
+) -> float | None:
+    components: List[tuple[float, float]] = []
+    if affinity is not None:
+        components.append((affinity, 0.5))
+    if expression is not None:
+        components.append((expression, 0.3))
+    if evidence is not None:
+        components.append((evidence, 0.2))
+    if not components:
+        return None
+    total_weight = sum(weight for _, weight in components)
+    if total_weight <= 0:
+        return None
+    score = sum(value * weight for value, weight in components) / total_weight
+    return float(max(0.05, min(0.95, score)))
+
+
+__all__ = ["GraphBackedReceptorAdapter", "ReceptorEvidenceBundle"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,3 +4,80 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+import pytest
+
+from backend.graph.models import (
+    BiolinkEntity,
+    BiolinkPredicate,
+    Edge,
+    Evidence,
+    Node,
+)
+from backend.graph.persistence import InMemoryGraphStore
+from backend.graph.service import GraphService
+from backend.simulation.kg_adapter import GraphBackedReceptorAdapter
+import backend.main as backend_main
+
+
+@pytest.fixture()
+def serotonin_graph(monkeypatch: pytest.MonkeyPatch) -> tuple[GraphService, GraphBackedReceptorAdapter]:
+    """Seed the in-memory knowledge graph with representative receptor edges."""
+
+    store = InMemoryGraphStore()
+    service = GraphService(store=store)
+    adapter = GraphBackedReceptorAdapter(service)
+
+    monkeypatch.setattr(backend_main, "GRAPH_SERVICE", service)
+    monkeypatch.setattr(backend_main, "KG_ADAPTER", adapter)
+
+    nodes = [
+        Node(id="CHEMBL:25", name="Sertraline", category=BiolinkEntity.CHEMICAL_SUBSTANCE),
+        Node(id="HGNC:HTR1A", name="HTR1A", category=BiolinkEntity.GENE),
+        Node(id="HGNC:HTR2A", name="HTR2A", category=BiolinkEntity.GENE),
+        Node(id="UBERON:0000955", name="Hippocampus", category=BiolinkEntity.BRAIN_REGION),
+    ]
+    edges = [
+        Edge(
+            subject="CHEMBL:25",
+            predicate=BiolinkPredicate.INTERACTS_WITH,
+            object="HGNC:HTR1A",
+            confidence=0.82,
+            evidence=[Evidence(source="ChEMBL", reference="PMID:1", confidence=0.88)],
+            qualifiers={"affinity": 0.83},
+        ),
+        Edge(
+            subject="CHEMBL:25",
+            predicate=BiolinkPredicate.INTERACTS_WITH,
+            object="HGNC:HTR2A",
+            confidence=0.45,
+            evidence=[Evidence(source="ChEMBL", reference="PMID:2", confidence=0.5)],
+        ),
+        Edge(
+            subject="UBERON:0000955",
+            predicate=BiolinkPredicate.EXPRESSES,
+            object="HGNC:HTR1A",
+            confidence=0.68,
+            evidence=[Evidence(source="AllenAtlas", reference="PMID:3", confidence=0.7)],
+            qualifiers={"expression": 0.72},
+        ),
+        Edge(
+            subject="UBERON:0000955",
+            predicate=BiolinkPredicate.EXPRESSES,
+            object="HGNC:HTR2A",
+            confidence=0.32,
+            evidence=[Evidence(source="AllenAtlas", reference="PMID:4", confidence=0.35)],
+        ),
+        Edge(
+            subject="HGNC:HTR1A",
+            predicate=BiolinkPredicate.COEXPRESSION_WITH,
+            object="HGNC:HTR2A",
+            confidence=0.4,
+            evidence=[Evidence(source="CoExp", reference="PMID:5", confidence=0.42)],
+            qualifiers={"weight": 0.38},
+        ),
+    ]
+    service.persist(nodes, edges)
+    adapter.clear_cache()
+
+    return service, adapter

--- a/backend/tests/test_kg_adapter.py
+++ b/backend/tests/test_kg_adapter.py
@@ -1,0 +1,71 @@
+from backend.graph.models import (
+    BiolinkEntity,
+    BiolinkPredicate,
+    Edge,
+    Evidence,
+    Node,
+)
+from backend.graph.persistence import InMemoryGraphStore
+from backend.graph.service import GraphService
+from backend.simulation.kg_adapter import GraphBackedReceptorAdapter
+
+
+def _build_adapter() -> tuple[GraphBackedReceptorAdapter, GraphService]:
+    store = InMemoryGraphStore()
+    service = GraphService(store=store)
+    adapter = GraphBackedReceptorAdapter(service)
+
+    nodes = [
+        Node(id="CHEMBL:25", name="Sertraline", category=BiolinkEntity.CHEMICAL_SUBSTANCE),
+        Node(id="HGNC:HTR1A", name="HTR1A", category=BiolinkEntity.GENE),
+        Node(id="UBERON:0000955", name="Hippocampus", category=BiolinkEntity.BRAIN_REGION),
+    ]
+    edges = [
+        Edge(
+            subject="CHEMBL:25",
+            predicate=BiolinkPredicate.INTERACTS_WITH,
+            object="HGNC:HTR1A",
+            confidence=0.8,
+            evidence=[Evidence(source="ChEMBL", reference="PMID:1", confidence=0.85)],
+            qualifiers={"affinity": 0.8},
+        ),
+        Edge(
+            subject="UBERON:0000955",
+            predicate=BiolinkPredicate.EXPRESSES,
+            object="HGNC:HTR1A",
+            confidence=0.6,
+            evidence=[Evidence(source="AllenAtlas", reference="PMID:2", confidence=0.7)],
+            qualifiers={"expression": 0.7},
+        ),
+    ]
+    service.persist(nodes, edges)
+    adapter.clear_cache()
+    return adapter, service
+
+
+def test_adapter_combines_interactions_and_expression():
+    adapter, _ = _build_adapter()
+    bundle = adapter.derive("5-HT1A", fallback_weight=0.3, fallback_evidence=0.4)
+
+    assert bundle.kg_weight > 0.3
+    assert bundle.affinity is not None and bundle.expression is not None
+    assert "ChEMBL" in bundle.evidence_sources
+
+
+def test_adapter_cache_invalidated_on_new_edges():
+    adapter, service = _build_adapter()
+    initial = adapter.derive("5-HT1A", fallback_weight=0.3, fallback_evidence=0.4)
+
+    extra_edge = Edge(
+        subject="CHEMBL:25",
+        predicate=BiolinkPredicate.INTERACTS_WITH,
+        object="HGNC:HTR1A",
+        confidence=0.9,
+        evidence=[Evidence(source="BindingDB", reference="PMID:3", confidence=0.9)],
+    )
+    service.persist([], [extra_edge])
+    adapter.invalidate("5-HT1A")
+    updated = adapter.derive("5-HT1A", fallback_weight=0.3, fallback_evidence=0.4)
+
+    assert updated.evidence_count > initial.evidence_count
+    assert "BindingDB" in updated.evidence_sources

--- a/backend/tests/test_main_simulation.py
+++ b/backend/tests/test_main_simulation.py
@@ -3,10 +3,8 @@ from fastapi.testclient import TestClient
 from backend.main import app
 
 
-client = TestClient(app)
-
-
-def test_simulate_endpoint_returns_confidence_and_timecourse():
+def test_simulate_endpoint_returns_confidence_and_timecourse(serotonin_graph):
+    client = TestClient(app)
     payload = {
         "receptors": {
             "5HT1A": {"occ": 0.6, "mech": "agonist"},
@@ -27,3 +25,9 @@ def test_simulate_endpoint_returns_confidence_and_timecourse():
     assert 0.0 <= data["confidence"]["DriveInvigoration"] <= 1.0
     assert len(data["details"]["timepoints"]) == len(data["details"]["trajectories"]["plasma_concentration"])
     assert data["details"]["timepoints"][-1] >= 168.0
+
+    ctx_1a = data["details"]["receptor_context"]["5-HT1A"]
+    ctx_2a = data["details"]["receptor_context"]["5-HT2A"]
+    assert ctx_1a["kg_weight"] > ctx_2a["kg_weight"]
+    assert ctx_1a["affinity"] is not None
+    assert "ChEMBL" in ctx_1a["sources"]

--- a/backend/tests/test_simulation_engine.py
+++ b/backend/tests/test_simulation_engine.py
@@ -37,3 +37,51 @@ def test_engine_chronic_ssri_profile():
     assert len(result.timepoints) == len(result.trajectories["plasma_concentration"])
     assert 0.0 <= result.confidence["DriveInvigoration"] <= 1.0
     assert result.scores["ApathyBlunting"] >= 0.0
+
+
+def test_affinity_expression_scaling_modulates_weights():
+    engine = SimulationEngine(time_step=6.0)
+
+    low_request = EngineRequest(
+        receptors={
+            "HTR1A": ReceptorEngagement(
+                name="HTR1A",
+                occupancy=0.6,
+                mechanism="agonist",
+                kg_weight=0.5,
+                evidence=0.6,
+                affinity=0.2,
+                expression=0.2,
+            )
+        },
+        regimen="acute",
+        adhd=False,
+        gut_bias=False,
+        pvt_weight=0.5,
+    )
+    high_request = EngineRequest(
+        receptors={
+            "HTR1A": ReceptorEngagement(
+                name="HTR1A",
+                occupancy=0.6,
+                mechanism="agonist",
+                kg_weight=0.5,
+                evidence=0.6,
+                affinity=0.95,
+                expression=0.9,
+            )
+        },
+        regimen="acute",
+        adhd=False,
+        gut_bias=False,
+        pvt_weight=0.5,
+    )
+
+    low_result = engine.run(low_request)
+    high_result = engine.run(high_request)
+
+    assert (
+        high_result.module_summaries["receptor_inputs"]["HTR1A"]["kg_weight"]
+        > low_result.module_summaries["receptor_inputs"]["HTR1A"]["kg_weight"]
+    )
+    assert high_result.scores["DriveInvigoration"] >= low_result.scores["DriveInvigoration"]


### PR DESCRIPTION
## Summary
- add a graph-backed receptor adapter that normalises interaction and expression evidence into reusable bundles
- extend the simulation engine and API endpoint to consume affinity, expression, and evidence sources when constructing receptor engagements and response metadata
- seed the test knowledge graph from fixtures and cover graph-driven execution through new adapter and simulation tests

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce7563ba5c832982734f7a5699730d