### PR TITLE
Add orchestrated API router and expand backend coverage

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,0 +1,5 @@
+"""API package for Neuropharm backend."""
+
+from .routes import create_router
+
+__all__ = ["create_router"]

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from fastapi import APIRouter, HTTPException, status
+
+from ..engine.receptors import (
+    RECEPTORS,
+    canonical_receptor_name,
+    get_mechanism_factor,
+    get_receptor_weights,
+)
+from ..graph.models import Edge, Node
+from ..graph.service import EvidenceSummary, GraphService
+from ..simulation import EngineRequest, ReceptorEngagement, SimulationEngine
+from .schemas import (
+    BaseSimulationRequest,
+    Citation,
+    EdgeSummary,
+    EvidenceDetail,
+    EvidenceSearchRequest,
+    ExplainRequest,
+    ExplainResponse,
+    ExplanationDriver,
+    GraphExpandRequest,
+    GraphFragmentResponse,
+    GraphGapItem,
+    GraphGapRequest,
+    GraphGapResponse,
+    NodeSummary,
+    PaginatedEvidenceResponse,
+    PredictEffectsRequest,
+    PredictEffectsResponse,
+    ReceptorContribution,
+    SimulationDetails,
+    SimulationRequest,
+    SimulationResponse,
+)
+
+SCORE_NAME_MAP: Dict[str, str] = {
+    "drive": "DriveInvigoration",
+    "apathy": "ApathyBlunting",
+    "motivation": "Motivation",
+    "cognitive_flexibility": "CognitiveFlexibility",
+    "anxiety": "Anxiety",
+    "sleep_quality": "SleepQuality",
+}
+SCORE_TO_METRIC = {value.lower(): key for key, value in SCORE_NAME_MAP.items()}
+SCORE_TO_METRIC.update({key: key for key in SCORE_NAME_MAP})
+
+REFS_PATH = Path(__file__).resolve().parents[1] / "refs.json"
+
+
+def _load_receptor_refs() -> Dict[str, List[Dict[str, str]]]:
+    try:
+        with REFS_PATH.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+            if isinstance(data, dict):
+                return {key: list(value) for key, value in data.items()}
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError:
+        return {}
+    return {}
+
+
+RECEPTOR_REFS = _load_receptor_refs()
+
+
+@dataclass(slots=True)
+class _ReceptorBreakdown:
+    receptor: str
+    canonical: str
+    mechanism: str
+    occupancy: float
+    metrics: Dict[str, float]
+    evidence: float
+    citations: List[Citation]
+
+
+def _edge_to_summary(edge: Edge) -> EdgeSummary:
+    return EdgeSummary(
+        subject=edge.subject,
+        predicate=edge.predicate,
+        object=edge.object,
+        relation=edge.relation,
+        knowledge_level=edge.knowledge_level,
+        confidence=edge.confidence,
+        publications=list(edge.publications),
+        evidence=[
+            EvidenceDetail(
+                source=ev.source,
+                reference=ev.reference,
+                confidence=ev.confidence,
+                uncertainty=ev.uncertainty,
+                annotations=dict(ev.annotations),
+            )
+            for ev in edge.evidence
+        ],
+        qualifiers=dict(edge.qualifiers),
+        created_at=edge.created_at.isoformat(),
+    )
+
+
+def _summary_to_model(summary: EvidenceSummary) -> EdgeSummary:
+    return _edge_to_summary(summary.edge)
+
+
+def _node_to_summary(node: Node) -> NodeSummary:
+    return NodeSummary(
+        id=node.id,
+        name=node.name,
+        category=node.category,
+        description=node.description,
+        provided_by=node.provided_by,
+        synonyms=list(node.synonyms),
+        xrefs=list(node.xrefs),
+        attributes=dict(node.attributes),
+    )
+
+
+def _evidence_level(canonical: str) -> float:
+    references = RECEPTOR_REFS.get(canonical, [])
+    return min(0.95, 0.45 + 0.1 * len(references))
+
+
+def _citations_for(canonical: str) -> List[Citation]:
+    return [Citation(**ref) for ref in RECEPTOR_REFS.get(canonical, [])]
+
+
+def _apply_modifiers(
+    entries: List[_ReceptorBreakdown], request: BaseSimulationRequest
+) -> Tuple[List[_ReceptorBreakdown], Dict[str, float], Dict[str, float]]:
+    modifiers: Dict[str, float] = {}
+
+    if request.gut_bias:
+        for entry in entries:
+            entry.metrics = {
+                metric: value * 0.9 if value < 0 else value for metric, value in entry.metrics.items()
+            }
+    if request.acute_1a:
+        for entry in entries:
+            entry.metrics = {metric: value * 0.75 for metric, value in entry.metrics.items()}
+
+    scale = 1.0 - request.pvt_weight * 0.2
+    for entry in entries:
+        entry.metrics = {metric: value * scale for metric, value in entry.metrics.items()}
+
+    totals = {metric: sum(entry.metrics.get(metric, 0.0) for entry in entries) for metric in SCORE_NAME_MAP}
+
+    if request.adhd:
+        totals["drive"] -= 0.3
+        totals["motivation"] -= 0.2
+        modifiers[SCORE_NAME_MAP["drive"]] = modifiers.get(SCORE_NAME_MAP["drive"], 0.0) - 6.0
+        modifiers[SCORE_NAME_MAP["motivation"]] = modifiers.get(SCORE_NAME_MAP["motivation"], 0.0) - 4.0
+
+    return entries, modifiers, totals
+
+
+def _compute_effects(request: BaseSimulationRequest) -> Tuple[
+    Dict[str, float],
+    List[ReceptorContribution],
+    Dict[str, float],
+    Dict[str, float],
+    List[str],
+]:
+    ignored: List[str] = []
+    breakdown: List[_ReceptorBreakdown] = []
+
+    for supplied_name, spec in request.receptors.items():
+        canonical = canonical_receptor_name(supplied_name)
+        if canonical not in RECEPTORS:
+            ignored.append(supplied_name)
+            continue
+        weights = get_receptor_weights(canonical)
+        factor = get_mechanism_factor(spec.mech)
+        metrics = {
+            metric: float(weights.get(metric, 0.0)) * spec.occ * factor for metric in SCORE_NAME_MAP
+        }
+        breakdown.append(
+            _ReceptorBreakdown(
+                receptor=supplied_name,
+                canonical=canonical,
+                mechanism=spec.mech,
+                occupancy=spec.occ,
+                metrics=metrics,
+                evidence=_evidence_level(canonical),
+                citations=_citations_for(canonical),
+            )
+        )
+
+    entries, modifiers, totals = _apply_modifiers(breakdown, request)
+
+    scores: Dict[str, float] = {}
+    for metric, score_name in SCORE_NAME_MAP.items():
+        change = 20.0 * totals.get(metric, 0.0)
+        if metric == "apathy":
+            value = 50.0 - change
+        else:
+            value = 50.0 + change
+        scores[score_name] = float(max(0.0, min(100.0, value)))
+
+    contributions: List[ReceptorContribution] = []
+    for entry in entries:
+        score_delta = {}
+        for metric, score_name in SCORE_NAME_MAP.items():
+            change = 20.0 * entry.metrics.get(metric, 0.0)
+            if metric == "apathy":
+                change *= -1.0
+            score_delta[score_name] = float(change)
+        contributions.append(
+            ReceptorContribution(
+                receptor=entry.receptor,
+                canonical_receptor=entry.canonical,
+                mechanism=entry.mechanism,
+                occupancy=entry.occupancy,
+                score_delta=score_delta,
+                evidence=entry.evidence,
+                uncertainty=float(max(0.0, min(1.0, 1.0 - entry.evidence))),
+                citations=list(entry.citations),
+            )
+        )
+
+    evidence_levels = [entry.evidence for entry in entries if entry.evidence is not None]
+    mean_evidence = sum(evidence_levels) / len(evidence_levels) if evidence_levels else 0.5
+    uncertainty = {
+        score_name: float(max(0.05, 1.0 - mean_evidence)) for score_name in SCORE_NAME_MAP.values()
+    }
+
+    return scores, contributions, uncertainty, modifiers, ignored
+
+
+def _build_engine_request(payload: SimulationRequest) -> Tuple[EngineRequest, Dict[str, List[Citation]], List[str]]:
+    regimen = payload.dosing
+    if payload.acute_1a:
+        regimen = "acute"
+
+    engagements: Dict[str, ReceptorEngagement] = {}
+    ignored: List[str] = []
+
+    for supplied_name, spec in payload.receptors.items():
+        canonical = canonical_receptor_name(supplied_name)
+        if canonical not in RECEPTORS:
+            ignored.append(supplied_name)
+            continue
+        weights = get_receptor_weights(canonical)
+        if weights:
+            kg_weight = sum(abs(weight) for weight in weights.values()) / len(weights)
+        else:
+            kg_weight = 0.25
+        engagements[canonical] = ReceptorEngagement(
+            name=canonical,
+            occupancy=spec.occ,
+            mechanism=spec.mech,
+            kg_weight=kg_weight,
+            evidence=_evidence_level(canonical),
+        )
+
+    engine_request = EngineRequest(
+        receptors=engagements,
+        regimen=regimen,
+        adhd=payload.adhd,
+        gut_bias=payload.gut_bias,
+        pvt_weight=payload.pvt_weight,
+    )
+
+    citations = {
+        canonical: _citations_for(canonical)
+        for canonical in engagements.keys()
+        if RECEPTOR_REFS.get(canonical)
+    }
+
+    return engine_request, citations, ignored
+
+
+def create_router(
+    graph_service: GraphService | None = None,
+    simulation_engine: SimulationEngine | None = None,
+) -> APIRouter:
+    service = graph_service or GraphService()
+    engine = simulation_engine or SimulationEngine(time_step=1.0)
+
+    router = APIRouter()
+
+    @router.post("/evidence/search", response_model=PaginatedEvidenceResponse)
+    def search_evidence(payload: EvidenceSearchRequest) -> PaginatedEvidenceResponse:
+        predicate_raw = payload.predicate
+        predicate = predicate_raw.value if hasattr(predicate_raw, "value") else predicate_raw
+        summaries = service.get_evidence(
+            subject=payload.subject,
+            predicate=predicate,
+            object_=payload.object,
+        )
+        total = len(summaries)
+        start = (payload.page - 1) * payload.page_size
+        end = start + payload.page_size
+        page_items = summaries[start:end]
+        return PaginatedEvidenceResponse(
+            results=[_summary_to_model(summary) for summary in page_items],
+            page=payload.page,
+            page_size=payload.page_size,
+            total=total,
+        )
+
+    @router.post("/graph/expand", response_model=GraphFragmentResponse)
+    def expand_graph(payload: GraphExpandRequest) -> GraphFragmentResponse:
+        fragment = service.expand(node_id=payload.node_id, depth=payload.depth, limit=payload.limit)
+        nodes = [_node_to_summary(node) for node in fragment.nodes]
+        edges = [_edge_to_summary(edge) for edge in fragment.edges]
+        return GraphFragmentResponse(nodes=nodes, edges=edges)
+
+    @router.post("/predict/effects", response_model=PredictEffectsResponse)
+    def predict_effects(payload: PredictEffectsRequest) -> PredictEffectsResponse:
+        scores, contributions, uncertainty, modifiers, ignored = _compute_effects(payload)
+        return PredictEffectsResponse(
+            scores=scores,
+            contributions=contributions,
+            uncertainty=uncertainty,
+            modifiers=modifiers,
+            ignored_targets=ignored,
+        )
+
+    @router.post("/simulate", response_model=SimulationResponse)
+    def simulate(payload: SimulationRequest) -> SimulationResponse:
+        engine_request, citations, ignored = _build_engine_request(payload)
+        try:
+            result = engine.run(engine_request)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+        details = SimulationDetails(
+            timepoints=result.timepoints,
+            trajectories=result.trajectories,
+            modules=result.module_summaries,
+            ignored_receptors=ignored,
+        )
+        return SimulationResponse(
+            scores=result.scores,
+            details=details,
+            citations=citations,
+            confidence=result.confidence,
+        )
+
+    @router.post("/explain", response_model=ExplainResponse)
+    def explain(payload: ExplainRequest) -> ExplainResponse:
+        scores, contributions, uncertainty, modifiers, ignored = _compute_effects(payload)
+        metric_key: str
+        if payload.metric:
+            lookup = payload.metric.lower()
+            if lookup not in SCORE_TO_METRIC:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Unknown metric '{payload.metric}'.",
+                )
+            metric_key = SCORE_TO_METRIC[lookup]
+        else:
+            metric_key = "motivation"
+        score_name = SCORE_NAME_MAP[metric_key]
+        predicted_score = scores.get(score_name, 50.0)
+
+        sorted_contribs = sorted(
+            contributions,
+            key=lambda contrib: abs(contrib.score_delta.get(score_name, 0.0)),
+            reverse=True,
+        )
+        drivers: List[ExplanationDriver] = []
+        for contrib in sorted_contribs[:3]:
+            delta = contrib.score_delta.get(score_name, 0.0)
+            drivers.append(
+                ExplanationDriver(
+                    receptor=contrib.receptor,
+                    canonical_receptor=contrib.canonical_receptor,
+                    mechanism=contrib.mechanism,
+                    score_delta=delta,
+                    confidence=float(max(0.0, min(1.0, 1.0 - contrib.uncertainty))),
+                    citations=contrib.citations,
+                )
+            )
+
+        if not drivers:
+            summary = (
+                f"{score_name} is predicted at {predicted_score:.1f} (Δ {predicted_score - 50.0:+.1f}) "
+                "without recognised receptor drivers."
+            )
+        else:
+            top_phrases = []
+            for driver in drivers:
+                direction = "raises" if driver.score_delta >= 0 else "lowers"
+                top_phrases.append(
+                    f"{driver.canonical_receptor} ({driver.mechanism}) {direction} the score by {abs(driver.score_delta):.1f}"
+                )
+            modifier_delta = modifiers.get(score_name, 0.0)
+            modifier_clause = ""
+            if modifier_delta:
+                modifier_clause = f" Phenotype modifiers contribute {modifier_delta:+.1f}."
+            summary = (
+                f"{score_name} is predicted at {predicted_score:.1f} (Δ {predicted_score - 50.0:+.1f}). "
+                f"Key drivers: {', '.join(top_phrases)}.{modifier_clause}"
+            )
+        summary += f" Estimated uncertainty {uncertainty.get(score_name, 0.5):.2f}."
+
+        return ExplainResponse(
+            metric=score_name,
+            predicted_score=predicted_score,
+            summary=summary,
+            drivers=drivers,
+            uncertainty=uncertainty.get(score_name, 0.5),
+            modifiers=modifiers,
+            ignored_targets=ignored,
+        )
+
+    @router.post("/gaps", response_model=GraphGapResponse)
+    def graph_gaps(payload: GraphGapRequest) -> GraphGapResponse:
+        gaps = service.find_gaps(payload.focus)
+        items = [GraphGapItem(subject=gap.subject, object=gap.object, reason=gap.reason) for gap in gaps]
+        return GraphGapResponse(gaps=items)
+
+    return router

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt
+
+from ..graph.models import BiolinkEntity, BiolinkPredicate
+
+Mechanism = Literal["agonist", "antagonist", "partial", "inverse"]
+
+
+class Citation(BaseModel):
+    """Reference supporting a mechanism or receptor effect."""
+
+    title: str
+    pmid: Optional[str] = None
+    doi: Optional[str] = None
+
+
+class EvidenceDetail(BaseModel):
+    """Evidence record associated with an edge."""
+
+    source: str
+    reference: Optional[str] = None
+    confidence: Optional[float] = None
+    uncertainty: Optional[str] = None
+    annotations: Dict[str, Any] = Field(default_factory=dict)
+
+
+class EdgeSummary(BaseModel):
+    """Serializable representation of an edge and its evidence."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    subject: str
+    predicate: BiolinkPredicate
+    object: str
+    relation: str
+    knowledge_level: Optional[str] = None
+    confidence: Optional[float] = None
+    publications: List[str] = Field(default_factory=list)
+    evidence: List[EvidenceDetail] = Field(default_factory=list)
+    qualifiers: Dict[str, Any] = Field(default_factory=dict)
+    created_at: Optional[str] = None
+
+
+class NodeSummary(BaseModel):
+    """Serializable representation of a graph node."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    id: str
+    name: str
+    category: BiolinkEntity = BiolinkEntity.NAMED_THING
+    description: Optional[str] = None
+    provided_by: Optional[str] = None
+    synonyms: List[str] = Field(default_factory=list)
+    xrefs: List[str] = Field(default_factory=list)
+    attributes: Dict[str, Any] = Field(default_factory=dict)
+
+
+class EvidenceSearchRequest(BaseModel):
+    """Filter and pagination payload for evidence search."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    subject: Optional[str] = None
+    predicate: Optional[BiolinkPredicate] = None
+    object: Optional[str] = None
+    page: PositiveInt = Field(default=1, description="1-indexed page number")
+    page_size: PositiveInt = Field(
+        default=25,
+        le=100,
+        description="Maximum number of records to return per page (<=100).",
+    )
+
+
+class PaginatedEvidenceResponse(BaseModel):
+    """Paginated evidence query response."""
+
+    results: List[EdgeSummary] = Field(default_factory=list)
+    page: int
+    page_size: int
+    total: int
+
+
+class GraphExpandRequest(BaseModel):
+    """Payload for expanding a neighbourhood around a node."""
+
+    node_id: str = Field(description="Seed node identifier (CURIE or URI).")
+    depth: PositiveInt = Field(default=1, le=3, description="Traversal depth (max 3).")
+    limit: PositiveInt = Field(default=25, le=200, description="Maximum number of nodes to return.")
+
+
+class GraphFragmentResponse(BaseModel):
+    """Response containing expanded graph fragment."""
+
+    nodes: List[NodeSummary] = Field(default_factory=list)
+    edges: List[EdgeSummary] = Field(default_factory=list)
+
+
+class ReceptorSpec(BaseModel):
+    """Specification for a single receptor in prediction/simulation payloads."""
+
+    occ: float = Field(ge=0.0, le=1.0, description="Fractional receptor occupancy (0-1).")
+    mech: Mechanism
+
+
+class BaseSimulationRequest(BaseModel):
+    """Common fields shared by prediction/simulation payloads."""
+
+    receptors: Dict[str, ReceptorSpec]
+    acute_1a: bool = False
+    dosing: Literal["acute", "chronic"] = "chronic"
+    adhd: bool = False
+    gut_bias: bool = False
+    pvt_weight: float = Field(default=0.5, ge=0.0, le=1.0)
+
+
+class PredictEffectsRequest(BaseSimulationRequest):
+    """Request body for /predict/effects."""
+
+
+class SimulationRequest(BaseSimulationRequest):
+    """Request body for /simulate."""
+
+
+class ExplainRequest(BaseSimulationRequest):
+    """Request body for /explain."""
+
+    metric: Optional[str] = Field(
+        default=None,
+        description="Optional metric to focus on (e.g. 'Motivation' or 'DriveInvigoration').",
+    )
+
+
+class SimulationDetails(BaseModel):
+    """Structured details returned by the simulation engine."""
+
+    timepoints: List[float] = Field(default_factory=list)
+    trajectories: Dict[str, List[float]] = Field(default_factory=dict)
+    modules: Dict[str, Any] = Field(default_factory=dict)
+    ignored_receptors: List[str] = Field(default_factory=list)
+
+
+class SimulationResponse(BaseModel):
+    """Response payload for /simulate."""
+
+    scores: Dict[str, float]
+    details: SimulationDetails
+    citations: Dict[str, List[Citation]] = Field(default_factory=dict)
+    confidence: Dict[str, float]
+
+
+class ReceptorContribution(BaseModel):
+    """Per-receptor contribution summary returned by /predict/effects."""
+
+    receptor: str
+    canonical_receptor: str
+    mechanism: Mechanism
+    occupancy: float = Field(ge=0.0, le=1.0)
+    score_delta: Dict[str, float] = Field(
+        default_factory=dict,
+        description="Score delta contributions in behavioural metric units.",
+    )
+    evidence: float = Field(ge=0.0, le=1.0)
+    uncertainty: float = Field(ge=0.0, le=1.0)
+    citations: List[Citation] = Field(default_factory=list)
+
+
+class PredictEffectsResponse(BaseModel):
+    """Response payload for /predict/effects."""
+
+    scores: Dict[str, float]
+    contributions: List[ReceptorContribution] = Field(default_factory=list)
+    uncertainty: Dict[str, float]
+    modifiers: Dict[str, float] = Field(default_factory=dict)
+    ignored_targets: List[str] = Field(default_factory=list)
+
+
+class ExplanationDriver(BaseModel):
+    """Driver entry surfaced by the /explain endpoint."""
+
+    receptor: str
+    canonical_receptor: str
+    mechanism: Mechanism
+    score_delta: float
+    confidence: float = Field(ge=0.0, le=1.0)
+    citations: List[Citation] = Field(default_factory=list)
+
+
+class ExplainResponse(BaseModel):
+    """Response payload for /explain."""
+
+    metric: str
+    predicted_score: float
+    summary: str
+    drivers: List[ExplanationDriver] = Field(default_factory=list)
+    uncertainty: float = Field(ge=0.0, le=1.0)
+    modifiers: Dict[str, float] = Field(default_factory=dict)
+    ignored_targets: List[str] = Field(default_factory=list)
+
+
+class GraphGapRequest(BaseModel):
+    """Payload describing the focus nodes for /gaps."""
+
+    focus: List[str] = Field(..., min_length=1, max_length=100)
+
+
+class GraphGapItem(BaseModel):
+    """Single gap description."""
+
+    subject: str
+    object: str
+    reason: str
+
+
+class GraphGapResponse(BaseModel):
+    """Response payload for /gaps."""
+
+    gaps: List[GraphGapItem] = Field(default_factory=list)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,113 +1,26 @@
-"""
-FastAPI backend for the neuropharm simulation lab.
+"""FastAPI application entry-point for the Neuropharm simulation API."""
 
-This service exposes a `/simulate` endpoint that accepts a JSON
-payload describing the current receptor occupancy, acute/chronic flags,
-phenotype modifiers (such as ADHD), gut-bias toggles, and other
-parameters. It returns computed scores for motivational drive, apathy
-blunting, and other high‑level readouts.  The current implementation
-provides a simple placeholder model to demonstrate the API and wiring;
-future work should extend this file with a full mechanistic model of
-serotonin, dopamine, glutamate, histamine, and other systems across
-brain regions.
+from __future__ import annotations
 
-The API also exposes a root `/` endpoint for a basic health check.
-"""
-
-from fastapi import FastAPI, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
-from typing import Any, Dict, Literal
-
-import json
 import os
-from pathlib import Path
 
-from .engine.receptors import (
-    RECEPTORS,
-    canonical_receptor_name,
-    get_receptor_weights,
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .api import create_router
+from .graph.service import GraphService
+from .simulation import SimulationEngine
+
+
+app = FastAPI(
+    title="Neuropharm Simulation API",
+    description=(
+        "Simulate serotonergic, dopaminergic and other neurotransmitter systems "
+        "under diverse receptor manipulations, inspect graph evidence, and "
+        "generate mechanism-aware explanations."
+    ),
 )
-from .simulation import EngineRequest, ReceptorEngagement, SimulationEngine
 
-
-Mechanism = Literal["agonist", "antagonist", "partial", "inverse"]
-
-
-REFS_PATH = Path(__file__).with_name("refs.json")
-try:
-    with REFS_PATH.open("r", encoding="utf-8") as f:
-        RECEPTOR_REFS: dict[str, list[dict[str, str]]] = json.load(f)
-except FileNotFoundError:
-    RECEPTOR_REFS = {}
-
-ENGINE = SimulationEngine(time_step=1.0)
-
-# -----------------------------------------------------------------------------
-# Pydantic models
-# -----------------------------------------------------------------------------
-
-class ReceptorSpec(BaseModel):
-    """Specification for a single receptor.
-
-    Attributes
-    ----------
-    occ : float
-        Fractional occupancy of the receptor (0.0–1.0).
-    mech : str
-        Mechanism of the ligand ("agonist", "antagonist", "partial", or
-        "inverse").  Future versions may support additional values.
-    """
-    occ: float = Field(ge=0.0, le=1.0)
-    mech: Mechanism
-
-
-class SimulationInput(BaseModel):
-    """Input payload for the simulation.
-
-    Fields are deliberately flexible to allow future extensions
-    (additional neurotransmitters, receptor subtypes, etc.).
-    """
-    receptors: Dict[str, ReceptorSpec]
-    acute_1a: bool = False
-    dosing: Literal["acute", "chronic"] = "chronic"
-    adhd: bool = False
-    gut_bias: bool = False
-    pvt_weight: float = 0.5
-
-
-class Citation(BaseModel):
-    """Reference supporting a mechanism or receptor effect."""
-
-    title: str
-    pmid: str
-    doi: str
-
-
-class SimulationOutput(BaseModel):
-    """Return format from the simulation engine.
-
-    `scores` contains high‑level behavioural metrics normalised to 0–100.
-    `details` includes intermediate values (e.g. computed dopamine phasic
-    drive) that may be useful for debugging or future UI visualisations.
-    `citations` returns a list of PubMed IDs and/or DOIs supporting the
-    mechanisms involved in generating the result.  `confidence` provides a
-    0–1 certainty estimate for each behavioural score.
-    """
-    scores: Dict[str, float]
-    details: Dict[str, Any]
-    citations: Dict[str, list[Citation]]
-    confidence: Dict[str, float]
-
-
-# -----------------------------------------------------------------------------
-# Application
-# -----------------------------------------------------------------------------
-
-app = FastAPI(title="Neuropharm Simulation API",
-              description=("Simulate serotonergic, dopaminergic and other\n                           neurotransmitter systems under a variety of\n                           receptor manipulations.  See the README for\n                           details on the expected payload format."))
-
-# Configure CORS
 origins = os.environ.get("CORS_ORIGINS", "https://darkfrostx-cmd.github.io").split(",")
 app.add_middleware(
     CORSMiddleware,
@@ -117,77 +30,24 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+_graph_service = GraphService()
+_simulation_engine = SimulationEngine(time_step=1.0)
+
+app.state.graph_service = _graph_service
+app.state.simulation_engine = _simulation_engine
+
+app.include_router(create_router(graph_service=_graph_service, simulation_engine=_simulation_engine))
+
 
 @app.get("/")
-def read_root():
-    """Health check endpoint.
+def read_root() -> dict[str, str]:
+    """Health check endpoint."""
 
-    Returns a basic status message so that clients can confirm the API is
-    running.
-    """
     return {"status": "ok", "version": "2025.09.05"}
-
 
 
 @app.get("/health")
-def health():
+def health() -> dict[str, str]:
+    """Alias for :func:`read_root` used by uptime monitors."""
+
     return {"status": "ok", "version": "2025.09.05"}
-
-@app.post("/simulate", response_model=SimulationOutput)
-def simulate(inp: SimulationInput) -> SimulationOutput:
-    """Run a single simulation with the provided input."""
-
-    regimen: Literal["acute", "chronic"] = inp.dosing
-    if inp.acute_1a:
-        regimen = "acute"
-
-    engagements: Dict[str, ReceptorEngagement] = {}
-    for rec_name, spec in inp.receptors.items():
-        canon = canonical_receptor_name(rec_name)
-        if canon not in RECEPTORS:
-            continue
-        weights = get_receptor_weights(canon)
-        if weights:
-            kg_weight = sum(abs(w) for w in weights.values()) / len(weights)
-        else:
-            kg_weight = 0.25
-        evidence = min(0.95, 0.45 + 0.1 * len(RECEPTOR_REFS.get(canon, [])))
-        engagements[canon] = ReceptorEngagement(
-            name=canon,
-            occupancy=spec.occ,
-            mechanism=spec.mech,
-            kg_weight=kg_weight,
-            evidence=evidence,
-        )
-
-    engine_request = EngineRequest(
-        receptors=engagements,
-        regimen=regimen,
-        adhd=inp.adhd,
-        gut_bias=inp.gut_bias,
-        pvt_weight=inp.pvt_weight,
-    )
-
-    try:
-        result = ENGINE.run(engine_request)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    citations: Dict[str, list[Citation]] = {}
-    for rec_name in inp.receptors.keys():
-        canon = canonical_receptor_name(rec_name)
-        if canon in RECEPTOR_REFS:
-            citations[canon] = [Citation(**ref) for ref in RECEPTOR_REFS[canon]]
-
-    details = {
-        "timepoints": result.timepoints,
-        "trajectories": result.trajectories,
-        "modules": result.module_summaries,
-    }
-
-    return SimulationOutput(
-        scores=result.scores,
-        details=details,
-        citations=citations,
-        confidence=result.confidence,
-    )

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,0 +1,1267 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Neuropharm Simulation API",
+    "description": "Simulate serotonergic, dopaminergic and other neurotransmitter systems under diverse receptor manipulations, inspect graph evidence, and generate mechanism-aware explanations.",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/evidence/search": {
+      "post": {
+        "summary": "Search Evidence",
+        "operationId": "search_evidence_evidence_search_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvidenceSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedEvidenceResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/graph/expand": {
+      "post": {
+        "summary": "Expand Graph",
+        "operationId": "expand_graph_graph_expand_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GraphExpandRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GraphFragmentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predict/effects": {
+      "post": {
+        "summary": "Predict Effects",
+        "operationId": "predict_effects_predict_effects_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictEffectsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictEffectsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/simulate": {
+      "post": {
+        "summary": "Simulate",
+        "operationId": "simulate_simulate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimulationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimulationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/explain": {
+      "post": {
+        "summary": "Explain",
+        "operationId": "explain_explain_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExplainRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExplainResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gaps": {
+      "post": {
+        "summary": "Graph Gaps",
+        "operationId": "graph_gaps_gaps_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GraphGapRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GraphGapResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Read Root",
+        "description": "Health check endpoint.",
+        "operationId": "read_root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Read Root  Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Alias for :func:`read_root` used by uptime monitors.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BiolinkEntity": {
+        "type": "string",
+        "enum": [
+          "biolink:NamedThing",
+          "biolink:Gene",
+          "biolink:ChemicalSubstance",
+          "biolink:Disease",
+          "biolink:AnatomicalEntity",
+          "biolink:PhenotypicFeature",
+          "biolink:Publication",
+          "biolink:Cell",
+          "biolink:BrainRegion",
+          "biolink:Pathway",
+          "biolink:Person"
+        ],
+        "title": "BiolinkEntity",
+        "description": "Supported Biolink categories."
+      },
+      "BiolinkPredicate": {
+        "type": "string",
+        "enum": [
+          "biolink:related_to",
+          "biolink:treats",
+          "biolink:affects",
+          "biolink:expresses",
+          "biolink:interacts_with",
+          "biolink:contributes_to",
+          "biolink:coexpressed_with",
+          "biolink:located_in",
+          "biolink:associated_with",
+          "biolink:part_of"
+        ],
+        "title": "BiolinkPredicate",
+        "description": "Subset of Biolink predicates used by the ingestion jobs."
+      },
+      "Citation": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "pmid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pmid"
+          },
+          "doi": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Doi"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "Citation",
+        "description": "Reference supporting a mechanism or receptor effect."
+      },
+      "EdgeSummary": {
+        "properties": {
+          "subject": {
+            "type": "string",
+            "title": "Subject"
+          },
+          "predicate": {
+            "$ref": "#/components/schemas/BiolinkPredicate"
+          },
+          "object": {
+            "type": "string",
+            "title": "Object"
+          },
+          "relation": {
+            "type": "string",
+            "title": "Relation"
+          },
+          "knowledge_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Knowledge Level"
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "publications": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Publications"
+          },
+          "evidence": {
+            "items": {
+              "$ref": "#/components/schemas/EvidenceDetail"
+            },
+            "type": "array",
+            "title": "Evidence"
+          },
+          "qualifiers": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Qualifiers"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "subject",
+          "predicate",
+          "object",
+          "relation"
+        ],
+        "title": "EdgeSummary",
+        "description": "Serializable representation of an edge and its evidence."
+      },
+      "EvidenceDetail": {
+        "properties": {
+          "source": {
+            "type": "string",
+            "title": "Source"
+          },
+          "reference": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference"
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "uncertainty": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uncertainty"
+          },
+          "annotations": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Annotations"
+          }
+        },
+        "type": "object",
+        "required": [
+          "source"
+        ],
+        "title": "EvidenceDetail",
+        "description": "Evidence record associated with an edge."
+      },
+      "EvidenceSearchRequest": {
+        "properties": {
+          "subject": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject"
+          },
+          "predicate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BiolinkPredicate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "object": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object"
+          },
+          "page": {
+            "type": "integer",
+            "exclusiveMinimum": 0.0,
+            "title": "Page",
+            "description": "1-indexed page number",
+            "default": 1
+          },
+          "page_size": {
+            "type": "integer",
+            "maximum": 100.0,
+            "exclusiveMinimum": 0.0,
+            "title": "Page Size",
+            "description": "Maximum number of records to return per page (<=100).",
+            "default": 25
+          }
+        },
+        "type": "object",
+        "title": "EvidenceSearchRequest",
+        "description": "Filter and pagination payload for evidence search."
+      },
+      "ExplainRequest": {
+        "properties": {
+          "receptors": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ReceptorSpec"
+            },
+            "type": "object",
+            "title": "Receptors"
+          },
+          "acute_1a": {
+            "type": "boolean",
+            "title": "Acute 1A",
+            "default": false
+          },
+          "dosing": {
+            "type": "string",
+            "enum": [
+              "acute",
+              "chronic"
+            ],
+            "title": "Dosing",
+            "default": "chronic"
+          },
+          "adhd": {
+            "type": "boolean",
+            "title": "Adhd",
+            "default": false
+          },
+          "gut_bias": {
+            "type": "boolean",
+            "title": "Gut Bias",
+            "default": false
+          },
+          "pvt_weight": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Pvt Weight",
+            "default": 0.5
+          },
+          "metric": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric",
+            "description": "Optional metric to focus on (e.g. 'Motivation' or 'DriveInvigoration')."
+          }
+        },
+        "type": "object",
+        "required": [
+          "receptors"
+        ],
+        "title": "ExplainRequest",
+        "description": "Request body for /explain."
+      },
+      "ExplainResponse": {
+        "properties": {
+          "metric": {
+            "type": "string",
+            "title": "Metric"
+          },
+          "predicted_score": {
+            "type": "number",
+            "title": "Predicted Score"
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary"
+          },
+          "drivers": {
+            "items": {
+              "$ref": "#/components/schemas/ExplanationDriver"
+            },
+            "type": "array",
+            "title": "Drivers"
+          },
+          "uncertainty": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Uncertainty"
+          },
+          "modifiers": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Modifiers"
+          },
+          "ignored_targets": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Ignored Targets"
+          }
+        },
+        "type": "object",
+        "required": [
+          "metric",
+          "predicted_score",
+          "summary",
+          "uncertainty"
+        ],
+        "title": "ExplainResponse",
+        "description": "Response payload for /explain."
+      },
+      "ExplanationDriver": {
+        "properties": {
+          "receptor": {
+            "type": "string",
+            "title": "Receptor"
+          },
+          "canonical_receptor": {
+            "type": "string",
+            "title": "Canonical Receptor"
+          },
+          "mechanism": {
+            "type": "string",
+            "enum": [
+              "agonist",
+              "antagonist",
+              "partial",
+              "inverse"
+            ],
+            "title": "Mechanism"
+          },
+          "score_delta": {
+            "type": "number",
+            "title": "Score Delta"
+          },
+          "confidence": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Confidence"
+          },
+          "citations": {
+            "items": {
+              "$ref": "#/components/schemas/Citation"
+            },
+            "type": "array",
+            "title": "Citations"
+          }
+        },
+        "type": "object",
+        "required": [
+          "receptor",
+          "canonical_receptor",
+          "mechanism",
+          "score_delta",
+          "confidence"
+        ],
+        "title": "ExplanationDriver",
+        "description": "Driver entry surfaced by the /explain endpoint."
+      },
+      "GraphExpandRequest": {
+        "properties": {
+          "node_id": {
+            "type": "string",
+            "title": "Node Id",
+            "description": "Seed node identifier (CURIE or URI)."
+          },
+          "depth": {
+            "type": "integer",
+            "maximum": 3.0,
+            "exclusiveMinimum": 0.0,
+            "title": "Depth",
+            "description": "Traversal depth (max 3).",
+            "default": 1
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 200.0,
+            "exclusiveMinimum": 0.0,
+            "title": "Limit",
+            "description": "Maximum number of nodes to return.",
+            "default": 25
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_id"
+        ],
+        "title": "GraphExpandRequest",
+        "description": "Payload for expanding a neighbourhood around a node."
+      },
+      "GraphFragmentResponse": {
+        "properties": {
+          "nodes": {
+            "items": {
+              "$ref": "#/components/schemas/NodeSummary"
+            },
+            "type": "array",
+            "title": "Nodes"
+          },
+          "edges": {
+            "items": {
+              "$ref": "#/components/schemas/EdgeSummary"
+            },
+            "type": "array",
+            "title": "Edges"
+          }
+        },
+        "type": "object",
+        "title": "GraphFragmentResponse",
+        "description": "Response containing expanded graph fragment."
+      },
+      "GraphGapItem": {
+        "properties": {
+          "subject": {
+            "type": "string",
+            "title": "Subject"
+          },
+          "object": {
+            "type": "string",
+            "title": "Object"
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason"
+          }
+        },
+        "type": "object",
+        "required": [
+          "subject",
+          "object",
+          "reason"
+        ],
+        "title": "GraphGapItem",
+        "description": "Single gap description."
+      },
+      "GraphGapRequest": {
+        "properties": {
+          "focus": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 1,
+            "title": "Focus"
+          }
+        },
+        "type": "object",
+        "required": [
+          "focus"
+        ],
+        "title": "GraphGapRequest",
+        "description": "Payload describing the focus nodes for /gaps."
+      },
+      "GraphGapResponse": {
+        "properties": {
+          "gaps": {
+            "items": {
+              "$ref": "#/components/schemas/GraphGapItem"
+            },
+            "type": "array",
+            "title": "Gaps"
+          }
+        },
+        "type": "object",
+        "title": "GraphGapResponse",
+        "description": "Response payload for /gaps."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "NodeSummary": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "category": {
+            "$ref": "#/components/schemas/BiolinkEntity",
+            "default": "biolink:NamedThing"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "provided_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provided By"
+          },
+          "synonyms": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Synonyms"
+          },
+          "xrefs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Xrefs"
+          },
+          "attributes": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Attributes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "NodeSummary",
+        "description": "Serializable representation of a graph node."
+      },
+      "PaginatedEvidenceResponse": {
+        "properties": {
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/EdgeSummary"
+            },
+            "type": "array",
+            "title": "Results"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "page_size": {
+            "type": "integer",
+            "title": "Page Size"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "page",
+          "page_size",
+          "total"
+        ],
+        "title": "PaginatedEvidenceResponse",
+        "description": "Paginated evidence query response."
+      },
+      "PredictEffectsRequest": {
+        "properties": {
+          "receptors": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ReceptorSpec"
+            },
+            "type": "object",
+            "title": "Receptors"
+          },
+          "acute_1a": {
+            "type": "boolean",
+            "title": "Acute 1A",
+            "default": false
+          },
+          "dosing": {
+            "type": "string",
+            "enum": [
+              "acute",
+              "chronic"
+            ],
+            "title": "Dosing",
+            "default": "chronic"
+          },
+          "adhd": {
+            "type": "boolean",
+            "title": "Adhd",
+            "default": false
+          },
+          "gut_bias": {
+            "type": "boolean",
+            "title": "Gut Bias",
+            "default": false
+          },
+          "pvt_weight": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Pvt Weight",
+            "default": 0.5
+          }
+        },
+        "type": "object",
+        "required": [
+          "receptors"
+        ],
+        "title": "PredictEffectsRequest",
+        "description": "Request body for /predict/effects."
+      },
+      "PredictEffectsResponse": {
+        "properties": {
+          "scores": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Scores"
+          },
+          "contributions": {
+            "items": {
+              "$ref": "#/components/schemas/ReceptorContribution"
+            },
+            "type": "array",
+            "title": "Contributions"
+          },
+          "uncertainty": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Uncertainty"
+          },
+          "modifiers": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Modifiers"
+          },
+          "ignored_targets": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Ignored Targets"
+          }
+        },
+        "type": "object",
+        "required": [
+          "scores",
+          "uncertainty"
+        ],
+        "title": "PredictEffectsResponse",
+        "description": "Response payload for /predict/effects."
+      },
+      "ReceptorContribution": {
+        "properties": {
+          "receptor": {
+            "type": "string",
+            "title": "Receptor"
+          },
+          "canonical_receptor": {
+            "type": "string",
+            "title": "Canonical Receptor"
+          },
+          "mechanism": {
+            "type": "string",
+            "enum": [
+              "agonist",
+              "antagonist",
+              "partial",
+              "inverse"
+            ],
+            "title": "Mechanism"
+          },
+          "occupancy": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Occupancy"
+          },
+          "score_delta": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Score Delta",
+            "description": "Score delta contributions in behavioural metric units."
+          },
+          "evidence": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Evidence"
+          },
+          "uncertainty": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Uncertainty"
+          },
+          "citations": {
+            "items": {
+              "$ref": "#/components/schemas/Citation"
+            },
+            "type": "array",
+            "title": "Citations"
+          }
+        },
+        "type": "object",
+        "required": [
+          "receptor",
+          "canonical_receptor",
+          "mechanism",
+          "occupancy",
+          "evidence",
+          "uncertainty"
+        ],
+        "title": "ReceptorContribution",
+        "description": "Per-receptor contribution summary returned by /predict/effects."
+      },
+      "ReceptorSpec": {
+        "properties": {
+          "occ": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Occ",
+            "description": "Fractional receptor occupancy (0-1)."
+          },
+          "mech": {
+            "type": "string",
+            "enum": [
+              "agonist",
+              "antagonist",
+              "partial",
+              "inverse"
+            ],
+            "title": "Mech"
+          }
+        },
+        "type": "object",
+        "required": [
+          "occ",
+          "mech"
+        ],
+        "title": "ReceptorSpec",
+        "description": "Specification for a single receptor in prediction/simulation payloads."
+      },
+      "SimulationDetails": {
+        "properties": {
+          "timepoints": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Timepoints"
+          },
+          "trajectories": {
+            "additionalProperties": {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "title": "Trajectories"
+          },
+          "modules": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Modules"
+          },
+          "ignored_receptors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Ignored Receptors"
+          }
+        },
+        "type": "object",
+        "title": "SimulationDetails",
+        "description": "Structured details returned by the simulation engine."
+      },
+      "SimulationRequest": {
+        "properties": {
+          "receptors": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ReceptorSpec"
+            },
+            "type": "object",
+            "title": "Receptors"
+          },
+          "acute_1a": {
+            "type": "boolean",
+            "title": "Acute 1A",
+            "default": false
+          },
+          "dosing": {
+            "type": "string",
+            "enum": [
+              "acute",
+              "chronic"
+            ],
+            "title": "Dosing",
+            "default": "chronic"
+          },
+          "adhd": {
+            "type": "boolean",
+            "title": "Adhd",
+            "default": false
+          },
+          "gut_bias": {
+            "type": "boolean",
+            "title": "Gut Bias",
+            "default": false
+          },
+          "pvt_weight": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Pvt Weight",
+            "default": 0.5
+          }
+        },
+        "type": "object",
+        "required": [
+          "receptors"
+        ],
+        "title": "SimulationRequest",
+        "description": "Request body for /simulate."
+      },
+      "SimulationResponse": {
+        "properties": {
+          "scores": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Scores"
+          },
+          "details": {
+            "$ref": "#/components/schemas/SimulationDetails"
+          },
+          "citations": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/Citation"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "title": "Citations"
+          },
+          "confidence": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Confidence"
+          }
+        },
+        "type": "object",
+        "required": [
+          "scores",
+          "details",
+          "confidence"
+        ],
+        "title": "SimulationResponse",
+        "description": "Response payload for /simulate."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,15 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture(scope="session")
+def anyio_backend() -> str:
+    """Restrict anyio-powered tests to asyncio."""
+
+    return "asyncio"

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -1,0 +1,198 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend.graph.models import BiolinkEntity, BiolinkPredicate, Edge, Evidence, Node
+from backend.graph.persistence import InMemoryGraphStore
+from backend.main import app
+
+
+@pytest.fixture(autouse=True)
+def reset_graph_store() -> None:
+    service = app.state.graph_service
+    service.store = InMemoryGraphStore()
+
+
+@pytest.fixture
+async def client() -> AsyncClient:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+def seed_basic_graph() -> None:
+    service = app.state.graph_service
+    node_a = Node(id="CHEMBL:25", name="Example Compound", category=BiolinkEntity.CHEMICAL_SUBSTANCE)
+    node_b = Node(id="HP:0001250", name="Seizures", category=BiolinkEntity.PHENOTYPIC_FEATURE)
+    service.persist([node_a, node_b], [])
+
+    edge = Edge(
+        subject=node_a.id,
+        predicate=BiolinkPredicate.AFFECTS,
+        object=node_b.id,
+        knowledge_level="supporting",
+        confidence=0.82,
+        publications=["PMID:1"],
+        evidence=[Evidence(source="ChEMBL", reference="PMID:1", confidence=0.82, uncertainty="medium")],
+    )
+    service.persist([], [edge])
+
+
+@pytest.mark.anyio("asyncio")
+async def test_evidence_search_returns_paginated_results(client: AsyncClient) -> None:
+    seed_basic_graph()
+
+    response = await client.post(
+        "/evidence/search",
+        json={
+            "subject": "CHEMBL:25",
+            "predicate": BiolinkPredicate.AFFECTS.value,
+            "page": 1,
+            "page_size": 10,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert payload["results"][0]["subject"] == "CHEMBL:25"
+    assert payload["results"][0]["evidence"][0]["source"] == "ChEMBL"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_evidence_search_empty_results(client: AsyncClient) -> None:
+    response = await client.post(
+        "/evidence/search",
+        json={"subject": "CHEMBL:999", "page": 1, "page_size": 5},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 0
+    assert payload["results"] == []
+
+
+@pytest.mark.anyio("asyncio")
+async def test_evidence_search_validation_error(client: AsyncClient) -> None:
+    response = await client.post(
+        "/evidence/search",
+        json={"page": 0, "page_size": 0},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio("asyncio")
+async def test_graph_expand_returns_nodes_and_edges(client: AsyncClient) -> None:
+    seed_basic_graph()
+
+    response = await client.post(
+        "/graph/expand",
+        json={"node_id": "CHEMBL:25", "depth": 1, "limit": 5},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert any(node["id"] == "CHEMBL:25" for node in payload["nodes"])
+    assert payload["edges"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_predict_effects_returns_scores_and_contributions(client: AsyncClient) -> None:
+    response = await client.post(
+        "/predict/effects",
+        json={
+            "receptors": {"5HT1A": {"occ": 0.5, "mech": "agonist"}},
+            "dosing": "acute",
+            "gut_bias": True,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert "Motivation" in payload["scores"]
+    assert payload["contributions"]
+    assert payload["uncertainty"]["Motivation"] >= 0.0
+
+
+@pytest.mark.anyio("asyncio")
+async def test_predict_effects_reports_ignored_targets(client: AsyncClient) -> None:
+    response = await client.post(
+        "/predict/effects",
+        json={"receptors": {"NotAReceptor": {"occ": 0.3, "mech": "agonist"}}},
+    )
+    assert response.status_code == 200
+    assert response.json()["ignored_targets"] == ["NotAReceptor"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_predict_effects_validation_error_for_mechanism(client: AsyncClient) -> None:
+    response = await client.post(
+        "/predict/effects",
+        json={"receptors": {"5HT1A": {"occ": 0.5, "mech": "invalid"}}},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio("asyncio")
+async def test_explain_endpoint_returns_drivers(client: AsyncClient) -> None:
+    response = await client.post(
+        "/explain",
+        json={
+            "receptors": {
+                "5HT1A": {"occ": 0.6, "mech": "agonist"},
+                "5HT2A": {"occ": 0.2, "mech": "antagonist"},
+            },
+            "metric": "Motivation",
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["metric"] == "Motivation"
+    assert payload["drivers"]
+    assert "Estimated uncertainty" in payload["summary"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_explain_endpoint_rejects_unknown_metric(client: AsyncClient) -> None:
+    response = await client.post(
+        "/explain",
+        json={"receptors": {"5HT1A": {"occ": 0.5, "mech": "agonist"}}, "metric": "invalid"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio("asyncio")
+async def test_gaps_endpoint_identifies_missing_edges(client: AsyncClient) -> None:
+    service = app.state.graph_service
+    node_a = Node(id="HGNC:5", name="GeneA", category=BiolinkEntity.GENE)
+    node_b = Node(id="HGNC:6", name="GeneB", category=BiolinkEntity.GENE)
+    service.persist([node_a, node_b], [])
+
+    response = await client.post("/gaps", json={"focus": [node_a.id, node_b.id]})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["gaps"]
+    assert payload["gaps"][0]["subject"] == node_a.id
+
+
+@pytest.mark.anyio("asyncio")
+async def test_gaps_endpoint_handles_empty_result(client: AsyncClient) -> None:
+    service = app.state.graph_service
+    node_a = Node(id="HGNC:7", name="GeneC", category=BiolinkEntity.GENE)
+    node_b = Node(id="HGNC:8", name="GeneD", category=BiolinkEntity.GENE)
+    service.persist([node_a, node_b], [])
+    connecting_edge = Edge(
+        subject=node_a.id,
+        predicate=BiolinkPredicate.RELATED_TO,
+        object=node_b.id,
+        evidence=[Evidence(source="OpenAlex", reference="10.1000/example")],
+    )
+    service.persist([], [connecting_edge])
+
+    response = await client.post("/gaps", json={"focus": [node_a.id, node_b.id]})
+    assert response.status_code == 200
+    assert response.json()["gaps"] == []
+
+
+@pytest.mark.anyio("asyncio")
+async def test_openapi_schema_includes_new_routes(client: AsyncClient) -> None:
+    response = await client.get("/openapi.json")
+    assert response.status_code == 200
+    schema = response.json()
+    assert "/predict/effects" in schema["paths"]
+    assert "/explain" in schema["paths"]

--- a/backend/tests/test_main_simulation.py
+++ b/backend/tests/test_main_simulation.py
@@ -1,16 +1,16 @@
-from fastapi.testclient import TestClient
+import pytest
+from httpx import ASGITransport, AsyncClient
 
 from backend.main import app
 
 
-client = TestClient(app)
-
-
-def test_simulate_endpoint_returns_confidence_and_timecourse():
+@pytest.mark.anyio("asyncio")
+async def test_simulate_endpoint_returns_confidence_and_timecourse() -> None:
     payload = {
         "receptors": {
             "5HT1A": {"occ": 0.6, "mech": "agonist"},
             "5HT2A": {"occ": 0.3, "mech": "antagonist"},
+            "UNKNOWN": {"occ": 0.4, "mech": "agonist"},
         },
         "adhd": True,
         "gut_bias": False,
@@ -18,12 +18,18 @@ def test_simulate_endpoint_returns_confidence_and_timecourse():
         "dosing": "chronic",
     }
 
-    response = client.post("/simulate", json=payload)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/simulate", json=payload)
+
     assert response.status_code == 200
     data = response.json()
 
     assert "confidence" in data
     assert "DriveInvigoration" in data["scores"]
     assert 0.0 <= data["confidence"]["DriveInvigoration"] <= 1.0
-    assert len(data["details"]["timepoints"]) == len(data["details"]["trajectories"]["plasma_concentration"])
+    assert len(data["details"]["timepoints"]) == len(
+        data["details"]["trajectories"]["plasma_concentration"]
+    )
     assert data["details"]["timepoints"][-1] >= 168.0
+    assert "UNKNOWN" in data["details"]["ignored_receptors"]


### PR DESCRIPTION
## Summary
- add Pydantic request/response schemas covering evidence, graph, simulation, explanation, and gaps workflows
- implement a dedicated API router that orchestrates GraphService and SimulationEngine while replacing the inline /simulate handler
- refresh the generated OpenAPI specification and extend async httpx-based pytest coverage for the new endpoints

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce756150a88329bdca811d4dbdb372