### PR TITLE
Add embedding-based gap analysis and causal reports

### DIFF
--- a/backend/graph/__init__.py
+++ b/backend/graph/__init__.py
@@ -13,14 +13,18 @@ from .models import (
     Node,
 )
 from .bel import edge_to_bel, node_to_bel
+from .gaps import EmbeddingConfig, EmbeddingGapFinder, GapReport
 from .persistence import GraphFragment, GraphGap, GraphStore, InMemoryGraphStore
-from .service import GraphService, EvidenceSummary
+from .service import EvidenceSummary, GraphService
 
 __all__ = [
     "BiolinkEntity",
     "BiolinkPredicate",
     "Edge",
     "Evidence",
+    "EmbeddingConfig",
+    "EmbeddingGapFinder",
+    "GapReport",
     "GraphFragment",
     "GraphGap",
     "GraphService",

--- a/backend/graph/gaps.py
+++ b/backend/graph/gaps.py
@@ -1,0 +1,274 @@
+"""Gap detection utilities leveraging lightweight knowledge graph embeddings.
+
+The functions exposed here intentionally avoid heavyweight dependencies such as
+PyKEEN.  They provide a small TransE/RotatE-inspired embedding that can be
+trained directly against the :class:`~backend.graph.persistence.GraphStore`
+interface.  The resulting scores are used to rank plausible yet missing edges
+between a set of focus nodes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+import numpy as np
+
+from .models import BiolinkPredicate, Edge, Node
+from .persistence import GraphStore
+
+
+@dataclass(slots=True)
+class EmbeddingConfig:
+    """Configuration for the lightweight embedding trainer."""
+
+    embedding_dim: int = 16
+    learning_rate: float = 0.02
+    epochs: int = 150
+    negative_ratio: int = 2
+    regularization: float = 1e-3
+    seed: int = 13
+
+
+@dataclass(slots=True)
+class GapCandidate:
+    """Potential missing edge predicted by the embedding model."""
+
+    subject: str
+    object: str
+    predicate: BiolinkPredicate
+    score: float
+    impact: float
+    reason: str = "Embedding model highlighted this relation as a likely gap."
+    metadata: Dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class GapReport:
+    """Structured report shared with the API layer."""
+
+    subject: str
+    object: str
+    predicate: BiolinkPredicate
+    embedding_score: float
+    impact_score: float
+    reason: str
+    causal_effect: float | None = None
+    causal_direction: str | None = None
+    causal_confidence: float | None = None
+    counterfactual_summary: str | None = None
+    literature: List[str] = field(default_factory=list)
+
+
+class EmbeddingGapFinder:
+    """Train and query a simple TransE-like embedding over the graph."""
+
+    def __init__(self, store: GraphStore, config: EmbeddingConfig | None = None) -> None:
+        self.store = store
+        self.config = config or EmbeddingConfig()
+        self._node_index: Dict[str, int] = {}
+        self._relation_index: Dict[BiolinkPredicate, int] = {}
+        self._entity_embeddings: np.ndarray | None = None
+        self._relation_embeddings: np.ndarray | None = None
+        self._snapshot: Tuple[int, int] | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def rank_missing_edges(self, focus_nodes: Sequence[str], top_k: int = 5) -> List[GapCandidate]:
+        """Return the highest impact missing edges touching the focus nodes."""
+
+        self._ensure_model()
+        if self._entity_embeddings is None or self._relation_embeddings is None:
+            return []
+
+        nodes = {node.id: node for node in self._iter_nodes()}
+        focus_targets = set(focus_nodes)
+        edges = list(self._iter_edges())
+        existing = {(edge.subject, edge.predicate.value, edge.object) for edge in edges}
+        existing_pairs = self._existing_pair(existing)
+        degrees = self._compute_degrees(edges)
+        candidates: List[GapCandidate] = []
+        for subject in focus_nodes:
+            if subject not in self._node_index:
+                continue
+            for node_id in nodes:
+                if node_id == subject:
+                    continue
+                if (subject, node_id) not in existing_pairs:
+                    best = self._best_predicate(subject, node_id)
+                    if best is None:
+                        continue
+                    predicate, score = best
+                    impact = self._impact_score(score, degrees.get(subject, 0), degrees.get(node_id, 0))
+                    if node_id in focus_targets:
+                        impact /= 1.5
+                    candidates.append(
+                        GapCandidate(
+                            subject=subject,
+                            object=node_id,
+                            predicate=predicate,
+                            score=score,
+                            impact=impact,
+                            metadata={"degree_sum": float(degrees.get(subject, 0) + degrees.get(node_id, 0))},
+                        )
+                    )
+        candidates.sort(key=lambda candidate: candidate.impact, reverse=True)
+        return candidates[:top_k]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_model(self) -> None:
+        nodes = list(self._iter_nodes())
+        edges = list(self._iter_edges())
+        snapshot = (len(nodes), len(edges))
+        if self._entity_embeddings is not None and self._relation_embeddings is not None and snapshot == self._snapshot:
+            return
+        if not nodes or not edges:
+            self._entity_embeddings = None
+            self._relation_embeddings = None
+            self._snapshot = snapshot
+            return
+        self._prepare_indices(nodes, edges)
+        self._train_model(edges)
+        self._snapshot = snapshot
+
+    def _iter_nodes(self) -> Iterable[Node]:
+        try:
+            return self.store.all_nodes()
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            raise RuntimeError("Graph store cannot enumerate nodes") from exc
+
+    def _iter_edges(self) -> Iterable[Edge]:
+        try:
+            return self.store.all_edges()
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            raise RuntimeError("Graph store cannot enumerate edges") from exc
+
+    def _prepare_indices(self, nodes: Sequence[Node], edges: Sequence[Edge]) -> None:
+        self._node_index = {node.id: idx for idx, node in enumerate(nodes)}
+        unique_predicates = {edge.predicate for edge in edges}
+        self._relation_index = {predicate: idx for idx, predicate in enumerate(sorted(unique_predicates, key=lambda p: p.value))}
+        rng = np.random.default_rng(self.config.seed)
+        self._entity_embeddings = rng.normal(scale=0.1, size=(len(self._node_index), self.config.embedding_dim)).astype(np.float32)
+        self._relation_embeddings = rng.normal(scale=0.1, size=(len(self._relation_index), self.config.embedding_dim)).astype(np.float32)
+
+    def _train_model(self, edges: Sequence[Edge]) -> None:
+        if self._entity_embeddings is None or self._relation_embeddings is None:
+            return
+        triples = self._edges_to_triples(edges)
+        if not triples:
+            return
+        rng = np.random.default_rng(self.config.seed)
+        lr = self.config.learning_rate
+        reg = self.config.regularization
+        for _ in range(self.config.epochs):
+            rng.shuffle(triples)
+            for subject_idx, predicate_idx, object_idx in triples:
+                self._apply_positive_update(subject_idx, predicate_idx, object_idx, lr, reg)
+                for _ in range(self.config.negative_ratio):
+                    negative_idx = rng.integers(0, self._entity_embeddings.shape[0])
+                    if negative_idx == object_idx:
+                        continue
+                    self._apply_negative_update(subject_idx, predicate_idx, negative_idx, lr, reg)
+
+    def _edges_to_triples(self, edges: Sequence[Edge]) -> List[Tuple[int, int, int]]:
+        triples: List[Tuple[int, int, int]] = []
+        for edge in edges:
+            subj_idx = self._node_index.get(edge.subject)
+            obj_idx = self._node_index.get(edge.object)
+            pred_idx = self._relation_index.get(edge.predicate)
+            if subj_idx is None or obj_idx is None or pred_idx is None:
+                continue
+            triples.append((subj_idx, pred_idx, obj_idx))
+        return triples
+
+    def _apply_positive_update(self, subject_idx: int, predicate_idx: int, object_idx: int, lr: float, reg: float) -> None:
+        assert self._entity_embeddings is not None and self._relation_embeddings is not None
+        subject_vec = self._entity_embeddings[subject_idx]
+        predicate_vec = self._relation_embeddings[predicate_idx]
+        object_vec = self._entity_embeddings[object_idx]
+        diff = subject_vec + predicate_vec - object_vec
+        subject_vec -= lr * diff
+        predicate_vec -= lr * diff
+        object_vec += lr * diff
+        self._entity_embeddings[subject_idx] = self._project(subject_vec, reg)
+        self._relation_embeddings[predicate_idx] = self._project(predicate_vec, reg)
+        self._entity_embeddings[object_idx] = self._project(object_vec, reg)
+
+    def _apply_negative_update(self, subject_idx: int, predicate_idx: int, object_idx: int, lr: float, reg: float) -> None:
+        assert self._entity_embeddings is not None and self._relation_embeddings is not None
+        subject_vec = self._entity_embeddings[subject_idx]
+        predicate_vec = self._relation_embeddings[predicate_idx]
+        object_vec = self._entity_embeddings[object_idx]
+        diff = subject_vec + predicate_vec - object_vec
+        subject_vec += lr * diff
+        predicate_vec += lr * diff
+        object_vec -= lr * diff
+        self._entity_embeddings[subject_idx] = self._project(subject_vec, reg)
+        self._relation_embeddings[predicate_idx] = self._project(predicate_vec, reg)
+        self._entity_embeddings[object_idx] = self._project(object_vec, reg)
+
+    def _existing_pair(self, existing: set[Tuple[str, str, str]]) -> set[Tuple[str, str]]:
+        return {(subject, obj) for subject, _, obj in existing}
+
+    def _best_predicate(self, subject: str, object_: str) -> Tuple[BiolinkPredicate, float] | None:
+        if self._entity_embeddings is None or self._relation_embeddings is None:
+            return None
+        subj_idx = self._node_index.get(subject)
+        obj_idx = self._node_index.get(object_)
+        if subj_idx is None or obj_idx is None:
+            return None
+        best_score = -math.inf
+        best_predicate: BiolinkPredicate | None = None
+        for predicate, idx in self._relation_index.items():
+            score = self._score(subj_idx, idx, obj_idx)
+            if score > best_score:
+                best_score = score
+                best_predicate = predicate
+        if best_predicate is None:
+            return None
+        return best_predicate, best_score
+
+    def _score(self, subject_idx: int, predicate_idx: int, object_idx: int) -> float:
+        assert self._entity_embeddings is not None and self._relation_embeddings is not None
+        subject_vec = self._entity_embeddings[subject_idx]
+        predicate_vec = self._relation_embeddings[predicate_idx]
+        object_vec = self._entity_embeddings[object_idx]
+        distance = np.linalg.norm(subject_vec + predicate_vec - object_vec)
+        return float(-distance)
+
+    def _impact_score(self, embedding_score: float, subject_degree: int, object_degree: int) -> float:
+        degree_factor = math.log(2 + subject_degree + object_degree)
+        return embedding_score * degree_factor
+
+    @staticmethod
+    def _compute_degrees(edges: Sequence[Edge]) -> Dict[str, int]:
+        degrees: Dict[str, int] = {}
+        for edge in edges:
+            degrees[edge.subject] = degrees.get(edge.subject, 0) + 1
+            degrees[edge.object] = degrees.get(edge.object, 0) + 1
+        return degrees
+
+    def _project(self, vector: np.ndarray, reg: float) -> np.ndarray:
+        """Apply L2 regularisation and norm clipping to keep embeddings stable."""
+
+        vector = vector * (1 - reg)
+        norm = np.linalg.norm(vector)
+        if norm == 0:
+            return vector
+        max_norm = math.sqrt(self.config.embedding_dim)
+        if norm > max_norm:
+            vector = (vector / norm) * max_norm
+        return vector
+
+
+__all__ = [
+    "EmbeddingConfig",
+    "EmbeddingGapFinder",
+    "GapCandidate",
+    "GapReport",
+]
+

--- a/backend/graph/persistence.py
+++ b/backend/graph/persistence.py
@@ -61,6 +61,16 @@ class GraphStore:
     def find_gaps(self, focus_nodes: Sequence[str]) -> List[GraphGap]:  # pragma: no cover - interface
         raise NotImplementedError
 
+    def all_nodes(self) -> Sequence[Node]:  # pragma: no cover - interface
+        """Return all nodes stored in the backend."""
+
+        raise NotImplementedError
+
+    def all_edges(self) -> Sequence[Edge]:  # pragma: no cover - interface
+        """Return all edges stored in the backend."""
+
+        raise NotImplementedError
+
 
 class InMemoryGraphStore(GraphStore):
     """Simple in-memory graph store for tests and local development."""
@@ -147,6 +157,12 @@ class InMemoryGraphStore(GraphStore):
                         )
                     )
         return gaps
+
+    def all_nodes(self) -> Sequence[Node]:
+        return list(self._nodes.values())
+
+    def all_edges(self) -> Sequence[Edge]:
+        return list(self._edges.values())
 
 
 class Neo4jGraphStore(GraphStore):  # pragma: no cover - requires external service

--- a/backend/graph/service.py
+++ b/backend/graph/service.py
@@ -6,8 +6,11 @@ from dataclasses import dataclass
 from typing import Iterable, List, Sequence
 
 from ..config import DEFAULT_GRAPH_CONFIG, GraphConfig
+from ..reasoning import CausalEffectEstimator, CausalSummary
+from .gaps import EmbeddingConfig, EmbeddingGapFinder, GapReport
+from .ingest_openalex import OpenAlexClient  # type: ignore
 from .models import Edge, Evidence, Node
-from .persistence import GraphFragment, GraphGap, GraphStore, InMemoryGraphStore
+from .persistence import GraphFragment, GraphStore, InMemoryGraphStore
 
 
 @dataclass(slots=True)
@@ -21,12 +24,24 @@ class EvidenceSummary:
 class GraphService:
     """High-level service exposing evidence and graph queries."""
 
-    def __init__(self, store: GraphStore | None = None, config: GraphConfig | None = None) -> None:
+    def __init__(
+        self,
+        store: GraphStore | None = None,
+        config: GraphConfig | None = None,
+        embedding_config: EmbeddingConfig | None = None,
+        gap_finder: EmbeddingGapFinder | None = None,
+        causal_estimator: CausalEffectEstimator | None = None,
+        literature_client: OpenAlexClient | None = None,
+    ) -> None:
         self.config = config or DEFAULT_GRAPH_CONFIG
         if store is not None:
             self.store = store
         else:
             self.store = self._create_store(self.config)
+        self._embedding_config = embedding_config or EmbeddingConfig()
+        self._gap_finder = gap_finder or EmbeddingGapFinder(self.store, self._embedding_config)
+        self._causal_estimator = causal_estimator or CausalEffectEstimator()
+        self._literature_client = literature_client
 
     def _create_store(self, config: GraphConfig) -> GraphStore:
         if config.backend == "memory":
@@ -59,8 +74,30 @@ class GraphService:
     def expand(self, node_id: str, depth: int = 1, limit: int = 25) -> GraphFragment:
         return self.store.neighbors(node_id, depth=depth, limit=limit)
 
-    def find_gaps(self, node_ids: Sequence[str]) -> List[GraphGap]:
-        return self.store.find_gaps(node_ids)
+    def find_gaps(self, node_ids: Sequence[str], top_k: int = 5) -> List[GapReport]:
+        candidates = self._gap_finder.rank_missing_edges(node_ids, top_k=top_k)
+        if not candidates:
+            return []
+        reports: List[GapReport] = []
+        for candidate in candidates:
+            causal_summary = self._summarize_causal(candidate.subject, candidate.object)
+            literature = self._suggest_literature(candidate.subject, candidate.object)
+            reports.append(
+                GapReport(
+                    subject=candidate.subject,
+                    object=candidate.object,
+                    predicate=candidate.predicate,
+                    embedding_score=candidate.score,
+                    impact_score=candidate.impact,
+                    reason=candidate.reason,
+                    causal_effect=causal_summary.effect if causal_summary else None,
+                    causal_direction=causal_summary.direction if causal_summary else None,
+                    causal_confidence=causal_summary.confidence if causal_summary else None,
+                    counterfactual_summary=causal_summary.description if causal_summary else None,
+                    literature=literature,
+                )
+            )
+        return reports
 
     # ------------------------------------------------------------------
     # Persistence helpers used by ingestion jobs
@@ -68,6 +105,90 @@ class GraphService:
     def persist(self, nodes: Iterable[Node], edges: Iterable[Edge]) -> None:
         self.store.upsert_nodes(nodes)
         self.store.upsert_edges(edges)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _summarize_causal(self, subject: str, target: str) -> CausalSummary | None:
+        treatment_values, outcome_values = self._collect_causal_observations(subject, target)
+        if not treatment_values or not outcome_values:
+            return None
+        return self._causal_estimator.estimate_effect(
+            treatment_values,
+            outcome_values,
+            treatment_name=subject,
+            outcome_name=target,
+        )
+
+    def _collect_causal_observations(self, subject: str, target: str) -> tuple[List[float], List[float]]:
+        treatments: List[float] = []
+        outcomes: List[float] = []
+        try:
+            node = self.store.get_node(subject)
+        except NotImplementedError:  # pragma: no cover - depends on backend
+            node = None
+        if node is not None:
+            samples = node.attributes.get("causal_samples")
+            if isinstance(samples, list):
+                for sample in samples:
+                    if not isinstance(sample, dict):
+                        continue
+                    if sample.get("target") != target:
+                        continue
+                    treatments.append(float(sample.get("treatment", sample.get("treatment_value", 0.0))))
+                    outcomes.append(float(sample.get("outcome", sample.get("outcome_value", 0.0))))
+        try:
+            edges = self.store.get_edge_evidence(subject=subject)
+        except NotImplementedError:  # pragma: no cover - depends on backend
+            edges = []
+        for edge in edges:
+            qualifier_target = edge.qualifiers.get("target") if edge.qualifiers else None
+            if edge.object == target or qualifier_target == target:
+                treatment_val = edge.qualifiers.get("treatment_value") if edge.qualifiers else None
+                if treatment_val is None:
+                    treatment_val = edge.confidence if edge.confidence is not None else 1.0
+                outcome_val = None
+                if edge.qualifiers:
+                    outcome_val = (
+                        edge.qualifiers.get("outcome_value")
+                        or edge.qualifiers.get("delta")
+                        or edge.qualifiers.get("effect")
+                    )
+                if outcome_val is None:
+                    outcome_val = edge.confidence if edge.confidence is not None else 0.0
+                treatments.append(float(treatment_val))
+                outcomes.append(float(outcome_val))
+        return treatments, outcomes
+
+    def _suggest_literature(self, subject: str, target: str, limit: int = 3) -> List[str]:
+        client = self._ensure_literature_client()
+        if client is None:
+            return []
+        query = f"{subject} {target}"
+        suggestions: List[str] = []
+        try:
+            for record in client.iter_works(search=query, per_page=limit):
+                title = record.get("display_name") or "Unknown work"
+                year = record.get("publication_year")
+                identifier = record.get("id") or record.get("ids", {}).get("openalex")
+                snippet = f"{title} ({year})" if year else title
+                if identifier:
+                    snippet = f"{snippet} [{identifier}]"
+                suggestions.append(snippet)
+                if len(suggestions) >= limit:
+                    break
+        except Exception:  # pragma: no cover - network errors
+            return []
+        return suggestions
+
+    def _ensure_literature_client(self) -> OpenAlexClient | None:
+        if self._literature_client is not None:
+            return self._literature_client
+        try:
+            self._literature_client = OpenAlexClient()
+        except Exception:  # pragma: no cover - optional dependency
+            self._literature_client = None
+        return self._literature_client
 
 
 __all__ = ["GraphService", "EvidenceSummary"]

--- a/backend/reasoning/__init__.py
+++ b/backend/reasoning/__init__.py
@@ -1,0 +1,6 @@
+"""Reasoning helpers built on top of the stored knowledge graph."""
+
+from .causal import CausalEffectEstimator, CausalSummary
+
+__all__ = ["CausalEffectEstimator", "CausalSummary"]
+

--- a/backend/reasoning/causal.py
+++ b/backend/reasoning/causal.py
@@ -1,0 +1,88 @@
+"""Simplified causal inference helpers.
+
+The implementation provides a light-weight alternative to DoWhy/EconML.  It
+estimates an average treatment effect using a difference-in-means estimator with
+Student's t confidence scoring.  The estimator intentionally accepts plain
+numeric sequences so that unit tests can seed synthetic observations without
+external dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Sequence
+
+import numpy as np
+
+
+@dataclass(slots=True)
+class CausalSummary:
+    """Summary of an estimated causal effect."""
+
+    treatment: str
+    outcome: str
+    effect: float
+    direction: str
+    confidence: float
+    n_treated: int
+    n_control: int
+    description: str
+
+
+class CausalEffectEstimator:
+    """Estimate treatment effects from observational samples."""
+
+    def __init__(self, minimum_samples: int = 2) -> None:
+        self.minimum_samples = minimum_samples
+
+    def estimate_effect(
+        self,
+        treatment_values: Sequence[float],
+        outcome_values: Sequence[float],
+        treatment_name: str,
+        outcome_name: str,
+    ) -> CausalSummary | None:
+        if len(treatment_values) != len(outcome_values) or len(treatment_values) < self.minimum_samples * 2:
+            return None
+        treatment = np.asarray(treatment_values, dtype=float)
+        outcome = np.asarray(outcome_values, dtype=float)
+        treated_mask = treatment > np.median(treatment)
+        control_mask = ~treated_mask
+        if treated_mask.sum() < self.minimum_samples or control_mask.sum() < self.minimum_samples:
+            return None
+        treated_outcomes = outcome[treated_mask]
+        control_outcomes = outcome[control_mask]
+        treat_mean = float(treated_outcomes.mean())
+        control_mean = float(control_outcomes.mean())
+        effect = treat_mean - control_mean
+        direction = "increase" if effect > 0 else "decrease" if effect < 0 else "neutral"
+        variance_treated = float(treated_outcomes.var(ddof=1)) if treated_outcomes.size > 1 else 0.0
+        variance_control = float(control_outcomes.var(ddof=1)) if control_outcomes.size > 1 else 0.0
+        se = math.sqrt(
+            (variance_treated / max(treated_outcomes.size, 1)) + (variance_control / max(control_outcomes.size, 1))
+        )
+        if se == 0:
+            confidence = 0.5 if effect == 0 else 0.95
+        else:
+            t_stat = abs(effect) / se
+            confidence = float(1 / (1 + math.exp(-t_stat)))
+        description = (
+            f"{treatment_name} is estimated to cause a {direction} of {effect:.3f} "
+            f"in {outcome_name} (confidence {confidence:.2f}, n_treated={treated_outcomes.size}, "
+            f"n_control={control_outcomes.size})."
+        )
+        return CausalSummary(
+            treatment=treatment_name,
+            outcome=outcome_name,
+            effect=effect,
+            direction=direction,
+            confidence=confidence,
+            n_treated=int(treated_outcomes.size),
+            n_control=int(control_outcomes.size),
+            description=description,
+        )
+
+
+__all__ = ["CausalEffectEstimator", "CausalSummary"]
+

--- a/backend/tests/test_gap_analysis.py
+++ b/backend/tests/test_gap_analysis.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import List
+
+from backend.graph.gaps import GapReport
+from backend.graph.models import BiolinkEntity, BiolinkPredicate, Edge, Evidence, Node
+from backend.graph.persistence import InMemoryGraphStore
+from backend.graph.service import GraphService
+
+
+class StubOpenAlexClient:
+    def iter_works(self, concept: str | None = None, search: str | None = None, per_page: int = 25):
+        yield {
+            "id": "https://openalex.org/W123",
+            "display_name": "HTR2A modulation improves anxiety behaviour",
+            "publication_year": 2022,
+        }
+        yield {
+            "id": "https://openalex.org/W456",
+            "display_name": "Serotonin receptor signalling case study",
+            "publication_year": 2021,
+        }
+
+
+def build_gap_store() -> tuple[InMemoryGraphStore, str, str, str]:
+    store = InMemoryGraphStore()
+    receptor = Node(
+        id="HGNC:6",
+        name="HTR2A",
+        category=BiolinkEntity.GENE,
+        attributes={
+            "causal_samples": [
+                {"target": "HP:0000729", "treatment": 0.0, "outcome": 0.1},
+                {"target": "HP:0000729", "treatment": 1.0, "outcome": 0.9},
+                {"target": "HP:0000729", "treatment": 0.5, "outcome": 0.4},
+                {"target": "HP:0000729", "treatment": 1.2, "outcome": 1.0},
+            ]
+        },
+    )
+    behaviour = Node(
+        id="HP:0000729",
+        name="Anxiety",
+        category=BiolinkEntity.PHENOTYPIC_FEATURE,
+    )
+    drug = Node(
+        id="CHEMBL:25",
+        name="Sertraline",
+        category=BiolinkEntity.CHEMICAL_SUBSTANCE,
+    )
+    region = Node(
+        id="UBERON:0001950",
+        name="Cerebral cortex",
+        category=BiolinkEntity.ANATOMICAL_ENTITY,
+    )
+    other_behaviour = Node(
+        id="HP:0000739",
+        name="Irritability",
+        category=BiolinkEntity.PHENOTYPIC_FEATURE,
+    )
+    store.upsert_nodes([receptor, behaviour, drug, region, other_behaviour])
+    edges: List[Edge] = [
+        Edge(
+            subject=drug.id,
+            predicate=BiolinkPredicate.INTERACTS_WITH,
+            object=receptor.id,
+            confidence=0.85,
+            evidence=[Evidence(source="ChEMBL", reference="PMID:111")],
+        ),
+        Edge(
+            subject=receptor.id,
+            predicate=BiolinkPredicate.EXPRESSES,
+            object=region.id,
+            confidence=0.65,
+            evidence=[Evidence(source="GTEx", reference="PMID:222")],
+        ),
+        Edge(
+            subject=region.id,
+            predicate=BiolinkPredicate.RELATED_TO,
+            object=behaviour.id,
+            confidence=0.6,
+            evidence=[Evidence(source="NeuroSynth", reference="PMID:333")],
+        ),
+        Edge(
+            subject=drug.id,
+            predicate=BiolinkPredicate.AFFECTS,
+            object=behaviour.id,
+            confidence=0.72,
+            qualifiers={"target": behaviour.id, "treatment_value": 1.0, "outcome_value": 0.7},
+            evidence=[Evidence(source="ClinicalTrial", reference="PMID:444")],
+        ),
+        Edge(
+            subject=receptor.id,
+            predicate=BiolinkPredicate.RELATED_TO,
+            object=other_behaviour.id,
+            confidence=0.4,
+            evidence=[Evidence(source="OpenAlex", reference="10.1000/example")],
+        ),
+    ]
+    store.upsert_edges(edges)
+    return store, receptor.id, behaviour.id, drug.id
+
+
+def test_embedding_gap_predictions_rank_expected_edge() -> None:
+    store, receptor_id, behaviour_id, _ = build_gap_store()
+    service = GraphService(store=store, literature_client=StubOpenAlexClient())
+    reports = service.find_gaps([receptor_id, behaviour_id], top_k=5)
+    assert reports
+    target_report = next(report for report in reports if report.subject == receptor_id and report.object == behaviour_id)
+    assert isinstance(target_report, GapReport)
+    assert target_report.embedding_score < 0
+    assert target_report.predicate == BiolinkPredicate.AFFECTS
+    assert reports.index(target_report) <= 3
+
+
+def test_gap_report_includes_causal_summary_and_literature() -> None:
+    store, receptor_id, behaviour_id, _ = build_gap_store()
+    service = GraphService(store=store, literature_client=StubOpenAlexClient())
+    reports = service.find_gaps([receptor_id, behaviour_id], top_k=5)
+    report = next(report for report in reports if report.subject == receptor_id and report.object == behaviour_id)
+    assert report.causal_direction == "increase"
+    assert report.causal_effect is not None and report.causal_effect > 0
+    assert report.causal_confidence is not None and report.causal_confidence > 0.5
+    assert report.counterfactual_summary is not None and receptor_id in report.counterfactual_summary
+    assert report.literature and "openalex.org/W123" in report.literature[0]

--- a/backend/tests/test_graph_service.py
+++ b/backend/tests/test_graph_service.py
@@ -5,7 +5,8 @@ from backend.graph.models import (
     Evidence,
     Node,
 )
-from backend.graph.persistence import GraphGap, InMemoryGraphStore
+from backend.graph.gaps import GapReport
+from backend.graph.persistence import InMemoryGraphStore
 from backend.graph.service import GraphService
 
 
@@ -52,6 +53,7 @@ def test_expand_returns_fragment() -> None:
 def test_find_gaps_between_focus_nodes() -> None:
     store = build_store()
     service = GraphService(store=store)
-    gaps = service.find_gaps(["HGNC:5", "HGNC:6", "CHEMBL:25"])
+    gaps = service.find_gaps(["HGNC:5", "HGNC:6", "CHEMBL:25"], top_k=3)
     assert isinstance(gaps, list)
-    assert any(isinstance(gap, GraphGap) for gap in gaps)
+    assert all(isinstance(gap, GapReport) for gap in gaps)
+    assert any(gap.subject == "CHEMBL:25" and gap.object == "HGNC:6" for gap in gaps)


### PR DESCRIPTION
## Summary
- add a lightweight TransE-inspired embedding trainer that produces impact-ranked gap reports for focus nodes
- wire a causal effect estimator and OpenAlex literature suggestions into GraphService gap responses
- expand in-memory graph store utilities and add unit tests covering embedding rankings and causal reporting

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce7c03675083299b0319863806eb41