### PR TITLE
Replace np.trapezoid usage with numpy.trapz

### DIFF
--- a/backend/simulation/molecular.py
+++ b/backend/simulation/molecular.py
@@ -176,7 +176,7 @@ def simulate_cascade(params: MolecularCascadeParams) -> MolecularCascadeResult:
 
     transient_peak = float(np.max(mean_activity))
     steady_state = float(mean_activity[-1])
-    auc = float(np.trapezoid(mean_activity, time))
+    auc = float(np.trapz(mean_activity, time))
     duration = float(time[-1] - time[0])
     activation_index = float(auc / duration) if duration > 0 else steady_state
 

--- a/backend/simulation/pkpd.py
+++ b/backend/simulation/pkpd.py
@@ -74,9 +74,9 @@ def _simulate_with_ospsuite(params: PKPDParameters, time: npt.NDArray[np.float64
     brain = np.interp(time, simulation.time, simulation.brain_concentration)
 
     summary = {
-        "auc": float(np.trapezoid(plasma, time)),
+        "auc": float(np.trapz(plasma, time)),
         "cmax": float(np.max(plasma)),
-        "exposure_index": float(np.trapezoid(brain, time) / (params.simulation_hours + 1e-6)),
+        "exposure_index": float(np.trapz(brain, time) / (params.simulation_hours + 1e-6)),
         "duration_h": float(params.simulation_hours),
         "regimen": params.regimen,
         "backend": "ospsuite",
@@ -124,9 +124,9 @@ def _two_compartment_model(params: PKPDParameters) -> PKPDProfile:
         plasma[idx] = max(0.0, plasma_prev + dt * dpdt)
         brain[idx] = max(0.0, brain_prev + dt * dbdt)
 
-    auc = float(np.trapezoid(plasma, time))
+    auc = float(np.trapz(plasma, time))
     cmax = float(np.max(plasma)) if plasma.size else 0.0
-    exposure_index = float(np.trapezoid(brain, time) / (params.simulation_hours + 1e-6))
+    exposure_index = float(np.trapz(brain, time) / (params.simulation_hours + 1e-6))
 
     summary: Dict[str, float | str] = {
         "auc": auc,

--- a/backend/tests/test_simulation_engine.py
+++ b/backend/tests/test_simulation_engine.py
@@ -1,3 +1,5 @@
+import math
+
 from backend.simulation import (
     EngineRequest,
     ReceptorEngagement,
@@ -37,6 +39,15 @@ def test_engine_chronic_ssri_profile():
     assert len(result.timepoints) == len(result.trajectories["plasma_concentration"])
     assert 0.0 <= result.confidence["DriveInvigoration"] <= 1.0
     assert result.scores["ApathyBlunting"] >= 0.0
+    molecular_summary = result.module_summaries["molecular"]
+    pkpd_summary = result.module_summaries["pkpd"]
+    assert molecular_summary["backend"] in {"analytic", "pysb"}
+    assert pkpd_summary["backend"] in {"analytic", "ospsuite"}
+    assert math.isfinite(molecular_summary["transient_peak"])
+    assert math.isfinite(molecular_summary["steady_state"])
+    assert math.isfinite(molecular_summary["activation_index"])
+    assert pkpd_summary["auc"] >= 0.0
+    assert pkpd_summary["exposure_index"] >= 0.0
 
 
 def test_affinity_expression_scaling_modulates_weights():


### PR DESCRIPTION
## Summary
- replace the trapezoidal integration helper in the molecular and PK/PD simulators with `numpy.trapz`
- extend the chronic SSRI regression test to assert molecular and PK/PD summaries remain populated

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cefb5f979c83299b483bec1380245c