### PR TITLE
Align seed identifiers and harvest receptor aliases

### DIFF
--- a/backend/graph/data/seed_graph.json
+++ b/backend/graph/data/seed_graph.json
@@ -2,7 +2,7 @@
   "version": "2025-09-05",
   "nodes": [
     {
-      "id": "CHEMBL25",
+      "id": "CHEMBL:25",
       "name": "Sertraline",
       "category": "biolink:ChemicalSubstance",
       "provided_by": "ChEMBL",
@@ -15,7 +15,7 @@
       }
     },
     {
-      "id": "CHEMBL120",
+      "id": "CHEMBL:120",
       "name": "Fluoxetine",
       "category": "biolink:ChemicalSubstance",
       "provided_by": "ChEMBL",

--- a/backend/graph/models.py
+++ b/backend/graph/models.py
@@ -155,6 +155,8 @@ def normalize_identifier(category: BiolinkEntity, identifier: str) -> str:
     identifier = identifier.strip()
     if not identifier:
         raise ValueError("Empty identifier")
+    if identifier.lower().startswith("http") and category == BiolinkEntity.PUBLICATION:
+        return identifier
     if ":" in identifier and not identifier.lower().startswith("http"):
         prefix, local_id = identifier.split(":", 1)
         prefix = prefix.strip().upper()

--- a/backend/tests/test_graph_models.py
+++ b/backend/tests/test_graph_models.py
@@ -46,6 +46,11 @@ def test_normalize_identifier_known_prefixes(category, raw, expected) -> None:
     assert normalize_identifier(category, raw) == expected
 
 
+def test_normalize_identifier_preserves_http_publications() -> None:
+    identifier = "https://openalex.org/W1234567890"
+    assert normalize_identifier(BiolinkEntity.PUBLICATION, identifier) == identifier
+
+
 def test_edge_bel_export() -> None:
     drug = Node(id="CHEMBL:25", name="Sertraline", category=BiolinkEntity.CHEMICAL_SUBSTANCE)
     gene = Node(id="HGNC:5", name="SLC6A4", category=BiolinkEntity.GENE)

--- a/backend/tests/test_ingest_runner.py
+++ b/backend/tests/test_ingest_runner.py
@@ -30,8 +30,12 @@ def test_load_seed_graph_populates_store():
     assert loaded
     nodes = {node.id for node in store.all_nodes()}
     assert "CHEMBL:25" in nodes
+    assert "https://openalex.org/W1234567890" in nodes
     edges = list(store.all_edges())
     assert any(edge.subject == "CHEMBL:25" for edge in edges)
+    assert service.store.get_node("https://openalex.org/W1234567890") is not None
+    publication_edges = service.get_evidence(subject="https://openalex.org/W1234567890")
+    assert any(summary.edge.object == "HGNC:11068" for summary in publication_edges)
 
 
 def test_bootstrap_uses_plan_when_seed_disabled():


### PR DESCRIPTION
## Summary
- align the SSRI seed nodes with the CHEMBL: prefix that downstream edges and tests expect
- allow HTTP/HTTPS publication identifiers to pass through normalization so OpenAlex works remain reachable after seeding
- expand the receptor adapter to harvest HGNC aliases from the graph, reuse the lookup in the API, and add regression coverage for numeric IDs

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf35f7f8f88329ac07ecc5adf0460b