### PR TITLE
Add graph client dependencies to backend requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,12 @@ serverless databases:
    reads its connection info from environment variables, so Workers KV can store
    secrets safely.
 3. **Graph storage.** Point the backend at a free [Neo4j Aura][aura] instance by
-   setting `GRAPH_BACKEND=neo4j` and `GRAPH_URI=neo4j+s://...`. Mirror writes to
-   ArangoDB (or any document store) with the new mirror syntax:
+   setting `GRAPH_BACKEND=neo4j` and `GRAPH_URI=neo4j+s://...`. Install the
+   backend requirements so the Neo4j and ArangoDB clients are available, then
+   mirror writes to ArangoDB (or any document store) with the new mirror syntax:
 
    ```bash
+   pip install -r backend/requirements.txt
    GRAPH_BACKEND=neo4j
    GRAPH_URI=neo4j+s://<your-host>
    GRAPH_USERNAME=<user>

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,5 +5,7 @@ scipy>=1.8.0
 pydantic>=2.1.1
 requests>=2.31.0
 httpx>=0.27.0
+neo4j>=5.13.0
+python-arango>=7.5.5
 # Optional domain toolkits have been moved to requirements-optional.txt.
 # Install them manually when running the full PySB/OSP/TVB integration stack.


### PR DESCRIPTION
## Summary
- include the neo4j and python-arango drivers in the backend requirements so production builds have the graph clients available
- document the deployment command so the Aura/Arango setup instructions are copy-pasteable

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfd88cf5f48329996507286e683357