### PR TITLE
Configure ingestion workflow for production secrets

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -20,5 +20,15 @@ jobs:
         run: pip install -r backend/requirements.txt
       - name: Execute ingestion plan
         env:
-          GRAPH_BACKEND: memory
+          GRAPH_BACKEND: ${{ secrets.GRAPH_BACKEND }}
+          GRAPH_URI: ${{ secrets.GRAPH_URI }}
+          GRAPH_USERNAME: ${{ secrets.GRAPH_USERNAME }}
+          GRAPH_PASSWORD: ${{ secrets.GRAPH_PASSWORD }}
+          GRAPH_DATABASE: ${{ secrets.GRAPH_DATABASE }}
+          GRAPH_MIRROR_A_BACKEND: ${{ secrets.GRAPH_MIRROR_A_BACKEND }}
+          GRAPH_MIRROR_A_URI: ${{ secrets.GRAPH_MIRROR_A_URI }}
+          GRAPH_MIRROR_A_DATABASE: ${{ secrets.GRAPH_MIRROR_A_DATABASE }}
+          GRAPH_MIRROR_A_USERNAME: ${{ secrets.GRAPH_MIRROR_A_USERNAME }}
+          GRAPH_MIRROR_A_PASSWORD: ${{ secrets.GRAPH_MIRROR_A_PASSWORD }}
+          GRAPH_MIRROR_A_OPT_TLS: ${{ secrets.GRAPH_MIRROR_A_OPT_TLS }}
         run: python -m backend.graph.cli ingest --limit 50

--- a/README.md
+++ b/README.md
@@ -170,7 +170,22 @@ Jobs honour cooldown windows via the new `IngestionOrchestrator`, and state is
 persisted to `backend/graph/data/ingestion_state.json`. A scheduled GitHub
 Action (`.github/workflows/ingestion.yml`) executes `python -m
 backend.graph.cli ingest --limit 50` every morning (UTC) so Aura/Arango mirrors
-stay fresh without manual intervention.
+stay fresh without manual intervention. Populate the following GitHub secrets so
+the workflow can authenticate against your managed graph instances:
+
+- `GRAPH_BACKEND`, `GRAPH_URI`, `GRAPH_USERNAME`, `GRAPH_PASSWORD`
+  - Primary Neo4j Aura deployment (e.g. `neo4j+s://<hostname>`).
+- `GRAPH_DATABASE` *(optional)*
+  - Only required when your backend expects an explicit database name.
+- `GRAPH_MIRROR_A_BACKEND`, `GRAPH_MIRROR_A_URI`, `GRAPH_MIRROR_A_DATABASE`
+  - Mirror ArangoDB deployment that receives replicated writes.
+- `GRAPH_MIRROR_A_USERNAME`, `GRAPH_MIRROR_A_PASSWORD`
+  - Credentials for the Arango mirror user.
+- `GRAPH_MIRROR_A_OPT_TLS`
+  - Set to `true` to enforce TLS verification when the mirror requires it.
+
+Add additional `GRAPH_MIRROR_<NAME>_*` secrets if you replicate to more than one
+store; the ingestion CLI automatically discovers them during each run.
 
 [cf-pages]: https://developers.cloudflare.com/pages/
 [cf-workers]: https://developers.cloudflare.com/workers/


### PR DESCRIPTION
## Summary
- update the scheduled ingestion workflow to read graph connection details from GitHub secrets
- document the required secrets so operators can provision Aura/Arango credentials for automation

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfdc20e1a08329abfd49d4c46ebfd1