### PR TITLE
Document ingestion secrets for managed graph deployments

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -11,6 +11,18 @@ permissions:
 jobs:
   ingest:
     runs-on: ubuntu-latest
+    env:
+      GRAPH_BACKEND: ${{ secrets.GRAPH_BACKEND }}
+      GRAPH_URI: ${{ secrets.GRAPH_URI }}
+      GRAPH_USERNAME: ${{ secrets.GRAPH_USERNAME }}
+      GRAPH_PASSWORD: ${{ secrets.GRAPH_PASSWORD }}
+      GRAPH_DATABASE: ${{ secrets.GRAPH_DATABASE }}
+      GRAPH_MIRROR_A_BACKEND: ${{ secrets.GRAPH_MIRROR_A_BACKEND }}
+      GRAPH_MIRROR_A_URI: ${{ secrets.GRAPH_MIRROR_A_URI }}
+      GRAPH_MIRROR_A_DATABASE: ${{ secrets.GRAPH_MIRROR_A_DATABASE }}
+      GRAPH_MIRROR_A_USERNAME: ${{ secrets.GRAPH_MIRROR_A_USERNAME }}
+      GRAPH_MIRROR_A_PASSWORD: ${{ secrets.GRAPH_MIRROR_A_PASSWORD }}
+      GRAPH_MIRROR_A_OPT_TLS: ${{ secrets.GRAPH_MIRROR_A_OPT_TLS }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -19,16 +31,4 @@ jobs:
       - name: Install backend requirements
         run: pip install -r backend/requirements.txt
       - name: Execute ingestion plan
-        env:
-          GRAPH_BACKEND: ${{ secrets.GRAPH_BACKEND }}
-          GRAPH_URI: ${{ secrets.GRAPH_URI }}
-          GRAPH_USERNAME: ${{ secrets.GRAPH_USERNAME }}
-          GRAPH_PASSWORD: ${{ secrets.GRAPH_PASSWORD }}
-          GRAPH_DATABASE: ${{ secrets.GRAPH_DATABASE }}
-          GRAPH_MIRROR_A_BACKEND: ${{ secrets.GRAPH_MIRROR_A_BACKEND }}
-          GRAPH_MIRROR_A_URI: ${{ secrets.GRAPH_MIRROR_A_URI }}
-          GRAPH_MIRROR_A_DATABASE: ${{ secrets.GRAPH_MIRROR_A_DATABASE }}
-          GRAPH_MIRROR_A_USERNAME: ${{ secrets.GRAPH_MIRROR_A_USERNAME }}
-          GRAPH_MIRROR_A_PASSWORD: ${{ secrets.GRAPH_MIRROR_A_PASSWORD }}
-          GRAPH_MIRROR_A_OPT_TLS: ${{ secrets.GRAPH_MIRROR_A_OPT_TLS }}
         run: python -m backend.graph.cli ingest --limit 50

--- a/README.md
+++ b/README.md
@@ -177,19 +177,16 @@ Jobs honour cooldown windows via the new `IngestionOrchestrator`, and state is
 persisted to `backend/graph/data/ingestion_state.json`. A scheduled GitHub
 Action (`.github/workflows/ingestion.yml`) executes `python -m
 backend.graph.cli ingest --limit 50` every morning (UTC) so Aura/Arango mirrors
-stay fresh without manual intervention. Populate the following GitHub secrets so
-the workflow can authenticate against your managed graph instances:
+stay fresh without manual intervention. Before enabling the workflow, create the
+following GitHub secrets so the runner can reach your managed graph instances:
 
-- `GRAPH_BACKEND`, `GRAPH_URI`, `GRAPH_USERNAME`, `GRAPH_PASSWORD`
-  - Primary Neo4j Aura deployment (e.g. `neo4j+s://<hostname>`).
-- `GRAPH_DATABASE` *(optional)*
-  - Only required when your backend expects an explicit database name.
-- `GRAPH_MIRROR_A_BACKEND`, `GRAPH_MIRROR_A_URI`, `GRAPH_MIRROR_A_DATABASE`
-  - Mirror ArangoDB deployment that receives replicated writes.
-- `GRAPH_MIRROR_A_USERNAME`, `GRAPH_MIRROR_A_PASSWORD`
-  - Credentials for the Arango mirror user.
-- `GRAPH_MIRROR_A_OPT_TLS`
-  - Set to `true` to enforce TLS verification when the mirror requires it.
+| Secret(s) | Required | Purpose |
+| --- | --- | --- |
+| `GRAPH_BACKEND`, `GRAPH_URI`, `GRAPH_USERNAME`, `GRAPH_PASSWORD` | ✔️ | Connection settings for the primary Neo4j Aura deployment (e.g. `neo4j+s://<hostname>`). |
+| `GRAPH_DATABASE` | Optional | Only necessary when your Aura project expects an explicit database name. |
+| `GRAPH_MIRROR_A_BACKEND`, `GRAPH_MIRROR_A_URI`, `GRAPH_MIRROR_A_DATABASE` | ✔️ (if mirroring) | Location of the ArangoDB (or other supported) mirror that receives replicated writes. |
+| `GRAPH_MIRROR_A_USERNAME`, `GRAPH_MIRROR_A_PASSWORD` | ✔️ (if mirroring) | Service credentials for the mirror user. |
+| `GRAPH_MIRROR_A_OPT_TLS` | Optional | Set to `true` to enforce TLS verification when the mirror requires it. |
 
 Add additional `GRAPH_MIRROR_<NAME>_*` secrets if you replicate to more than one
 store; the ingestion CLI automatically discovers them during each run.


### PR DESCRIPTION
## Summary
- promote the knowledge-graph secrets to job-level environment variables in the ingestion workflow
- document the GitHub secrets needed to target Aura and Arango deployments in the scheduled ingestion run

## Testing
- python -m compileall backend/main.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d087b662588329a5c17f187a43f1a0