### PR TITLE
Add graph driver dependencies and document environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ pip install -r backend/requirements.txt
 uvicorn backend.main:app --host 0.0.0.0 --port 8000
 ```
 
+The base requirements now ship with the Neo4j (5.x) and python-arango clients so
+managed Aura and Oasis endpoints work without extra installs.
+
 The optional simulation toolkits (PySB, OSPSuite, TVB) pull heavy native wheels.
 Install them only when you need the full PK/PD stack:
 
@@ -87,6 +90,31 @@ npm test -- --watch=false
 script so CI and local runs behave the same way.
 
 ## Deployment notes
+
+### Graph connectivity environment variables
+
+Configure the graph driver through environment variables before deploying to
+Render, Cloudflare Workers or any other hosted stack:
+
+```bash
+GRAPH_BACKEND=neo4j
+GRAPH_URI=neo4j+s://<neo4j-host>
+GRAPH_USERNAME=<neo4j-user>
+GRAPH_PASSWORD=<neo4j-password>
+
+# Optional database selector when your Aura tenancy exposes multiple DBs
+GRAPH_DATABASE=<neo4j-database>
+
+# Mirror a managed ArangoDB instance (e.g. Oasis) alongside Aura
+GRAPH_MIRROR_A_BACKEND=arangodb
+GRAPH_MIRROR_A_URI=https://<arango-host>
+GRAPH_MIRROR_A_DATABASE=<arango-database>
+GRAPH_MIRROR_A_USERNAME=<arango-user>
+GRAPH_MIRROR_A_PASSWORD=<arango-password>
+
+# Enable strict TLS verification when the mirror requires SNI/cert checks
+GRAPH_MIRROR_A_OPT_TLS=true
+```
 
 ### GitHub Pages frontend
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ scipy>=1.8.0
 pydantic>=2.1.1
 requests>=2.31.0
 httpx>=0.27.0
-neo4j>=5.13.0  # Aura uses the 5.x protocol stack; keep the driver on 5.x or newer.
-python-arango>=7.5.5  # Includes the TLS/SNI fixes needed by managed Arango deployments.
+neo4j>=5.13,<6.0  # Aura uses the 5.x protocol stack; keep the driver on the 5.x line.
+python-arango>=7.5,<8.0  # Includes the TLS/SNI fixes needed by managed Arango deployments.
 # Optional domain toolkits have been moved to requirements-optional.txt.
 # Install them manually when running the full PySB/OSP/TVB integration stack.


### PR DESCRIPTION
## Summary
- tighten the Neo4j and python-arango pins in the default backend requirements
- document the graph connectivity environment variables needed for Aura and Arango deployments

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08c6a0ab48329bd806fc2967c711b