### PR TITLE
Secure ingestion workflow and expand ingestion secrets docs

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -11,6 +11,19 @@ permissions:
 jobs:
   ingest:
     runs-on: ubuntu-latest
+    env:
+      GRAPH_BACKEND: ${{ secrets.GRAPH_BACKEND }}
+      GRAPH_URI: ${{ secrets.GRAPH_URI }}
+      GRAPH_USERNAME: ${{ secrets.GRAPH_USERNAME }}
+      GRAPH_PASSWORD: ${{ secrets.GRAPH_PASSWORD }}
+      GRAPH_DATABASE: ${{ secrets.GRAPH_DATABASE }}
+      GRAPH_OPT_TLS: ${{ secrets.GRAPH_OPT_TLS }}
+      GRAPH_MIRROR_A_BACKEND: ${{ secrets.GRAPH_MIRROR_A_BACKEND }}
+      GRAPH_MIRROR_A_URI: ${{ secrets.GRAPH_MIRROR_A_URI }}
+      GRAPH_MIRROR_A_DATABASE: ${{ secrets.GRAPH_MIRROR_A_DATABASE }}
+      GRAPH_MIRROR_A_USERNAME: ${{ secrets.GRAPH_MIRROR_A_USERNAME }}
+      GRAPH_MIRROR_A_PASSWORD: ${{ secrets.GRAPH_MIRROR_A_PASSWORD }}
+      GRAPH_MIRROR_A_OPT_TLS: ${{ secrets.GRAPH_MIRROR_A_OPT_TLS }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -19,16 +32,4 @@ jobs:
       - name: Install backend requirements
         run: pip install -r backend/requirements.txt
       - name: Execute ingestion plan
-        env:
-          GRAPH_BACKEND: ${{ secrets.GRAPH_BACKEND }}
-          GRAPH_URI: ${{ secrets.GRAPH_URI }}
-          GRAPH_USERNAME: ${{ secrets.GRAPH_USERNAME }}
-          GRAPH_PASSWORD: ${{ secrets.GRAPH_PASSWORD }}
-          GRAPH_DATABASE: ${{ secrets.GRAPH_DATABASE }}
-          GRAPH_MIRROR_A_BACKEND: ${{ secrets.GRAPH_MIRROR_A_BACKEND }}
-          GRAPH_MIRROR_A_URI: ${{ secrets.GRAPH_MIRROR_A_URI }}
-          GRAPH_MIRROR_A_DATABASE: ${{ secrets.GRAPH_MIRROR_A_DATABASE }}
-          GRAPH_MIRROR_A_USERNAME: ${{ secrets.GRAPH_MIRROR_A_USERNAME }}
-          GRAPH_MIRROR_A_PASSWORD: ${{ secrets.GRAPH_MIRROR_A_PASSWORD }}
-          GRAPH_MIRROR_A_OPT_TLS: ${{ secrets.GRAPH_MIRROR_A_OPT_TLS }}
         run: python -m backend.graph.cli ingest --limit 50


### PR DESCRIPTION
## Summary
- load the ingestion workflow's graph connection settings from secrets at the job level, including TLS and mirror knobs
- document the GitHub Action secrets table and manual dry-run guidance in the README for operators

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08d87ca5883298345234fca5e4777