### PR TITLE
Bundle mechanistic simulation assets and broaden backend coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ The optional simulation toolkits (PySB, OSPSuite, TVB) pull heavy native wheels.
 Install them only when you need the full PK/PD stack:
 
 ```bash
-pip install -e backend[simulation]
+pip install -e backend[mechanistic]
 ```
 
+The legacy `backend[simulation]` extra still works if you bookmarked the older docs.
 If you prefer requirements files, `backend/requirements-optional.txt` mirrors the same pins.
 
 The backend now bundles reference PySB, OSPSuite and TVB assets under `backend/simulation/assets`,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+mechanistic = [
+    "pysb>=1.13.0",
+    "ospsuite>=11.0.0",
+    "tvb-library>=2.8.0",
+]
+# Backwards compatibility with older installation instructions.
 simulation = [
     "pysb>=1.13.0",
     "ospsuite>=11.0.0",

--- a/backend/simulation/circuit.py
+++ b/backend/simulation/circuit.py
@@ -208,4 +208,4 @@ def simulate_circuit_response(params: CircuitParameters) -> CircuitResponse:
     return _simulate_analytic(params, time)
 
 
-__all__ = ["CircuitParameters", "CircuitResponse", "simulate_circuit_response"]
+__all__ = ["CircuitParameters", "CircuitResponse", "simulate_circuit_response", "HAS_TVB"]

--- a/backend/simulation/molecular.py
+++ b/backend/simulation/molecular.py
@@ -39,6 +39,8 @@ except Exception:  # pragma: no cover - optional dependency
     Observable = None  # type: ignore[assignment]
     ScipyOdeSimulator = None  # type: ignore[assignment]
 
+HAS_PYSB = Model is not None
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -208,4 +210,4 @@ def simulate_cascade(params: MolecularCascadeParams) -> MolecularCascadeResult:
     )
 
 
-__all__ = ["MolecularCascadeParams", "MolecularCascadeResult", "simulate_cascade"]
+__all__ = ["MolecularCascadeParams", "MolecularCascadeResult", "simulate_cascade", "HAS_PYSB"]

--- a/backend/simulation/pkpd.py
+++ b/backend/simulation/pkpd.py
@@ -205,4 +205,4 @@ def simulate_pkpd(params: PKPDParameters) -> PKPDProfile:
     return _two_compartment_model(params)
 
 
-__all__ = ["PKPDParameters", "PKPDProfile", "simulate_pkpd"]
+__all__ = ["PKPDParameters", "PKPDProfile", "simulate_pkpd", "HAS_OSPSUITE"]


### PR DESCRIPTION
## Summary
- document the new `mechanistic` optional dependency extra and keep `simulation` as a backwards-compatible alias
- expose availability flags for the PySB, OSPSuite, and TVB backends and package the reference assets used by each
- extend the simulation backend tests to cover both analytic fallbacks and the optional mechanistic engines

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d315abeffc832986dd8d8a7ff732e0