### PR TITLE
Add DoWhy/EconML causal diagnostics and API counterfactuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ pip install -e backend[mechanistic]
 The legacy `backend[simulation]` extra still works if you bookmarked the older docs.
 If you prefer requirements files, `backend/requirements-optional.txt` mirrors the same pins.
 
+Install the causal diagnostics extra when you want DoWhy/EconML-backed assumption
+graphs and counterfactuals surfaced in the `/gaps` and `/explain` endpoints:
+
+```bash
+pip install -e backend[causal]
+```
+
+With the extra active the API responses include explicit assumption graphs,
+numerical counterfactual scenarios and refutation diagnostics alongside the
+lightweight analytic fallback.
+
 The backend now bundles reference PySB, OSPSuite and TVB assets under `backend/simulation/assets`,
 so the optional engines work out of the box once the extra is installed—no need to ship separate
 PK-Sim projects or connectivity matrices.

--- a/backend/graph/gaps.py
+++ b/backend/graph/gaps.py
@@ -15,6 +15,7 @@ from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
 
 import numpy as np
 
+from ..reasoning import CausalSummary, CounterfactualScenario
 from .models import BiolinkPredicate, Edge, Node
 from .persistence import GraphStore
 
@@ -54,12 +55,33 @@ class GapReport:
     embedding_score: float
     impact_score: float
     reason: str
-    causal_effect: float | None = None
-    causal_direction: str | None = None
-    causal_confidence: float | None = None
-    counterfactual_summary: str | None = None
+    causal: CausalSummary | None = None
     literature: List[str] = field(default_factory=list)
     metadata: Dict[str, object] = field(default_factory=dict)
+
+    @property
+    def causal_effect(self) -> float | None:
+        return self.causal.effect if self.causal else None
+
+    @property
+    def causal_direction(self) -> str | None:
+        return self.causal.direction if self.causal else None
+
+    @property
+    def causal_confidence(self) -> float | None:
+        return self.causal.confidence if self.causal else None
+
+    @property
+    def counterfactual_summary(self) -> str | None:
+        return self.causal.description if self.causal else None
+
+    @property
+    def counterfactuals(self) -> List[CounterfactualScenario]:
+        return list(self.causal.counterfactuals) if self.causal else []
+
+    @property
+    def assumption_graph(self) -> str | None:
+        return self.causal.assumption_graph if self.causal else None
 
 
 class EmbeddingGapFinder:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,11 @@ mechanistic = [
     "ospsuite>=11.0.0",
     "tvb-library>=2.8.0",
 ]
+# Causal inference helpers used by the knowledge-graph endpoints.
+causal = [
+    "dowhy>=0.11.1",
+    "econml>=0.14.1",
+]
 # Backwards compatibility with older installation instructions.
 simulation = [
     "pysb>=1.13.0",

--- a/backend/reasoning/__init__.py
+++ b/backend/reasoning/__init__.py
@@ -1,6 +1,6 @@
 """Reasoning helpers built on top of the stored knowledge graph."""
 
-from .causal import CausalEffectEstimator, CausalSummary
+from .causal import CausalEffectEstimator, CausalSummary, CounterfactualScenario
 
-__all__ = ["CausalEffectEstimator", "CausalSummary"]
+__all__ = ["CausalEffectEstimator", "CausalSummary", "CounterfactualScenario"]
 

--- a/backend/requirements-optional.txt
+++ b/backend/requirements-optional.txt
@@ -3,3 +3,7 @@
 pysb>=1.13.0
 ospsuite>=11.0.0
 tvb-library>=2.8.0
+
+# Causal inference add-ons for counterfactual diagnostics.
+dowhy>=0.11.1
+econml>=0.14.1

--- a/backend/tests/test_causal_estimator.py
+++ b/backend/tests/test_causal_estimator.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+import backend.reasoning.causal as causal_module
+from backend.reasoning.causal import CausalEffectEstimator
+
+
+def _synthetic_observations() -> tuple[list[float], list[float]]:
+    treatment = [0.0, 0.1, 0.2, 0.8, 1.0, 1.2]
+    outcome = [0.05, 0.1, 0.2, 0.9, 1.1, 1.25]
+    return treatment, outcome
+
+
+def test_difference_in_means_counterfactuals(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(causal_module, "CausalModel", None)
+    monkeypatch.setattr(causal_module, "LinearDML", None)
+    estimator = CausalEffectEstimator()
+    treatment, outcome = _synthetic_observations()
+    summary = estimator.estimate_effect(
+        treatment,
+        outcome,
+        treatment_name="HGNC:6",
+        outcome_name="HP:0000729",
+        assumptions={"graph": 'digraph { "HGNC:6" -> "HP:0000729"; }'},
+    )
+    assert summary is not None
+    assert summary.diagnostics.get("method") == "difference_in_means"
+    assert summary.assumption_graph is not None
+    assert len(summary.counterfactuals) >= 1
+    assert summary.counterfactuals[0].label in {"observed", "p10"}
+
+
+@pytest.mark.skipif(causal_module.CausalModel is None, reason="DoWhy not installed")
+def test_dowhy_enriches_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(causal_module, "LinearDML", None)
+    estimator = CausalEffectEstimator()
+    treatment, outcome = _synthetic_observations()
+    summary = estimator.estimate_effect(
+        treatment,
+        outcome,
+        treatment_name="HGNC:6",
+        outcome_name="HP:0000729",
+        assumptions={"graph": 'digraph { "HGNC:6" -> "HP:0000729"; }'},
+    )
+    assert summary is not None
+    assert summary.diagnostics.get("method", "").startswith("dowhy")
+    assert summary.assumption_graph is not None
+    assert summary.counterfactuals

--- a/backend/tests/test_gap_analysis.py
+++ b/backend/tests/test_gap_analysis.py
@@ -119,9 +119,14 @@ def test_gap_report_includes_causal_summary_and_literature() -> None:
     service = GraphService(store=store, literature_client=StubOpenAlexClient())
     reports = service.find_gaps([receptor_id, behaviour_id], top_k=5)
     report = next(report for report in reports if report.subject == receptor_id and report.object == behaviour_id)
+    assert report.causal is not None
     assert report.causal_direction == "increase"
     assert report.causal_effect is not None and report.causal_effect > 0
     assert report.causal_confidence is not None and report.causal_confidence > 0.5
     assert report.counterfactual_summary is not None and receptor_id in report.counterfactual_summary
+    assert report.counterfactuals
+    assert report.assumption_graph is not None and receptor_id in report.assumption_graph
+    assert report.causal.diagnostics
     assert report.literature and "openalex.org/W123" in report.literature[0]
     assert report.metadata.get("context_weight")
+    assert "assumption_graph" in report.metadata


### PR DESCRIPTION
## Summary
- add a causal optional-dependency extra and expand the estimator to build assumption graphs, counterfactuals, and richer diagnostics when DoWhy/EconML are available
- surface the new causal payload through the graph service, gap/explain API endpoints, and document the dependency knobs
- backfill unit tests that cover both the analytic fallback path and the optional-library integration

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d31a4425f08329b3957570e029e312