### PR TITLE
Enhance literature grounding, persistent embeddings, and gap triage UI

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -145,6 +145,7 @@ class VectorStoreConfig:
     options: MutableMapping[str, str] = field(default_factory=dict)
     pool_min: int = 1
     pool_max: int = 4
+    sqlite_path: Optional[str] = ".cache/embeddings.sqlite"
 
     def is_configured(self) -> bool:
         """Return ``True`` when a connection URL or host has been supplied."""
@@ -215,6 +216,8 @@ class VectorStoreConfig:
                 option_key = key[len(opt_prefix) :].lower()
                 options[option_key] = value
 
+        sqlite_path = env.get(f"{prefix}SQLITE_PATH")
+
         return cls(
             url=raw_url,
             host=host,
@@ -227,6 +230,7 @@ class VectorStoreConfig:
             options=options,
             pool_min=pool_min,
             pool_max=pool_max,
+            sqlite_path=sqlite_path or ".cache/embeddings.sqlite",
         )
 
 

--- a/backend/graph/data/__init__.py
+++ b/backend/graph/data/__init__.py
@@ -1,0 +1,2 @@
+"""Resource package for graph ingestion fixtures."""
+

--- a/backend/graph/data/grounding_synonyms.json
+++ b/backend/graph/data/grounding_synonyms.json
@@ -1,0 +1,59 @@
+{
+  "serotonin": {
+    "id": "CHEBI:28790",
+    "label": "Serotonin",
+    "category": "biolink:ChemicalSubstance",
+    "synonyms": ["5-HT", "5 hydroxytryptamine", "5-hydroxytryptamine"],
+    "xrefs": ["HMDB:HMDB0000259", "PUBCHEM:5202"]
+  },
+  "dopamine": {
+    "id": "CHEBI:18243",
+    "label": "Dopamine",
+    "category": "biolink:ChemicalSubstance",
+    "synonyms": ["3,4-dihydroxyphenethylamine", "DA"],
+    "xrefs": ["HMDB:HMDB0000073", "PUBCHEM:681"]
+  },
+  "brain-derived neurotrophic factor": {
+    "id": "HGNC:1033",
+    "label": "BDNF",
+    "category": "biolink:Gene",
+    "synonyms": ["Brain-derived neurotrophic factor", "Bdnf"],
+    "xrefs": ["NCBIGene:627", "ENSEMBL:ENSG00000176697"]
+  },
+  "bdnf": {
+    "id": "HGNC:1033",
+    "label": "BDNF",
+    "category": "biolink:Gene",
+    "synonyms": ["Brain-derived neurotrophic factor"],
+    "xrefs": ["NCBIGene:627"]
+  },
+  "prefrontal cortex": {
+    "id": "UBERON:0001870",
+    "label": "Prefrontal cortex",
+    "category": "biolink:BrainRegion",
+    "synonyms": ["PFC", "prefrontal cortical area"],
+    "xrefs": ["MBA:1143"]
+  },
+  "gaba": {
+    "id": "CHEBI:16865",
+    "label": "gamma-Aminobutyric acid",
+    "category": "biolink:ChemicalSubstance",
+    "synonyms": ["GABA"],
+    "xrefs": ["PUBCHEM:119"]
+  },
+  "slc6a4": {
+    "id": "HGNC:11048",
+    "label": "SLC6A4",
+    "category": "biolink:Gene",
+    "synonyms": ["SERT", "Serotonin transporter"],
+    "xrefs": ["NCBIGene:6532"]
+  },
+  "htr2a": {
+    "id": "HGNC:5293",
+    "label": "HTR2A",
+    "category": "biolink:Gene",
+    "synonyms": ["5-HT2A receptor"],
+    "xrefs": ["NCBIGene:3356"]
+  }
+}
+

--- a/backend/graph/entity_grounding.py
+++ b/backend/graph/entity_grounding.py
@@ -1,0 +1,180 @@
+"""Lightweight entity grounding helpers for the text-mining pipeline.
+
+The blueprint expects text-mined entities to resolve to persistent identifiers
+instead of the hash-based placeholders used during the initial scaffolding.
+The :class:`GroundingResolver` below provides a deterministic fallback that
+works entirely offline while leaving room for richer integrations when
+scispaCy/INDRA stacks are available.
+
+The resolver consults a curated synonym table for high-value neuropharmacology
+terms and falls back to heuristics for common identifier patterns (HGNC gene
+symbols, CHEBI compounds, and basic anatomy labels).  Each grounding attempt
+returns a :class:`GroundedEntity` with an estimated confidence so downstream
+code can surface the provenance to curators.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import resources
+import json
+import re
+from typing import Dict, Mapping, Tuple
+
+from .models import BiolinkEntity
+
+
+@dataclass(frozen=True)
+class GroundedEntity:
+    """Representation of a grounded mention."""
+
+    id: str
+    name: str
+    category: BiolinkEntity
+    confidence: float
+    synonyms: Tuple[str, ...] = ()
+    xrefs: Tuple[str, ...] = ()
+    provenance: Mapping[str, object] = None  # type: ignore[assignment]
+
+
+class GroundingResolver:
+    """Resolve free-text mentions to Biolink nodes."""
+
+    def __init__(self, *, synonym_table: Mapping[str, Mapping[str, object]] | None = None) -> None:
+        if synonym_table is None:
+            synonym_table = _load_default_synonyms()
+        self._synonyms = self._normalise_synonym_table(synonym_table)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def resolve(self, mention: str) -> GroundedEntity:
+        mention = mention.strip()
+        if not mention:
+            raise ValueError("Empty mention cannot be grounded")
+
+        lookup_key = mention.lower()
+        if lookup_key in self._synonyms:
+            record = self._synonyms[lookup_key]
+            return GroundedEntity(
+                id=record["id"],
+                name=record["label"],
+                category=record["category"],
+                confidence=0.92,
+                synonyms=tuple(record.get("synonyms", ())),
+                xrefs=tuple(record.get("xrefs", ())),
+                provenance={"strategy": "curated"},
+            )
+
+        heuristic = self._heuristic_ground(mention)
+        if heuristic is not None:
+            return heuristic
+
+        placeholder_id = f"TXT:{_slugify(mention)}"
+        return GroundedEntity(
+            id=placeholder_id,
+            name=mention,
+            category=BiolinkEntity.NAMED_THING,
+            confidence=0.35,
+            synonyms=(mention,),
+            provenance={"strategy": "fallback"},
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _heuristic_ground(self, mention: str) -> GroundedEntity | None:
+        token = mention.strip()
+        upper = token.upper()
+
+        # HGNC symbols are typically uppercase and <= 8 characters.
+        if 2 <= len(upper) <= 8 and upper.isalnum() and upper == token:
+            return GroundedEntity(
+                id=f"HGNC:{upper}",
+                name=token,
+                category=BiolinkEntity.GENE,
+                confidence=0.65,
+                synonyms=(token,),
+                provenance={"strategy": "heuristic_gene"},
+            )
+
+        # CHEBI identifiers often appear as CHEBI:#### or compound names ending with ine/ol.
+        if upper.startswith("CHEBI:"):
+            return GroundedEntity(
+                id=upper,
+                name=mention,
+                category=BiolinkEntity.CHEMICAL_SUBSTANCE,
+                confidence=0.7,
+                synonyms=(mention,),
+                provenance={"strategy": "heuristic_chebi"},
+            )
+
+        if re.search(r"(ine|ol|ate)$", token.lower()):
+            return GroundedEntity(
+                id=f"CHEBI:{_slugify(token)}",
+                name=token,
+                category=BiolinkEntity.CHEMICAL_SUBSTANCE,
+                confidence=0.55,
+                synonyms=(token,),
+                provenance={"strategy": "heuristic_compound"},
+            )
+
+        if "cortex" in token.lower() or "hippocampus" in token.lower():
+            return GroundedEntity(
+                id=f"UBERON:{_slugify(token)}",
+                name=token,
+                category=BiolinkEntity.BRAIN_REGION,
+                confidence=0.5,
+                synonyms=(token,),
+                provenance={"strategy": "heuristic_region"},
+            )
+
+        return None
+
+    @staticmethod
+    def _normalise_synonym_table(
+        raw: Mapping[str, Mapping[str, object]]
+    ) -> Dict[str, Dict[str, object]]:
+        table: Dict[str, Dict[str, object]] = {}
+        for _, record in raw.items():
+            label = str(record.get("label", "")).strip()
+            if not label:
+                continue
+            category = record.get("category")
+            if isinstance(category, str):
+                try:
+                    record_category = BiolinkEntity(category)
+                except ValueError:
+                    record_category = BiolinkEntity.NAMED_THING
+            elif isinstance(category, BiolinkEntity):
+                record_category = category
+            else:
+                record_category = BiolinkEntity.NAMED_THING
+            entry: Dict[str, object] = {
+                "id": str(record.get("id", label)),
+                "label": label,
+                "category": record_category,
+                "synonyms": tuple(sorted({label, *record.get("synonyms", [])}, key=str.lower)),
+                "xrefs": tuple(record.get("xrefs", ())),
+            }
+            for synonym in entry["synonyms"]:  # type: ignore[index]
+                key = synonym.lower()
+                table[key] = entry
+        return table
+
+
+def _load_default_synonyms() -> Mapping[str, Mapping[str, object]]:
+    with resources.files("backend.graph.data").joinpath("grounding_synonyms.json").open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return payload
+
+
+def _slugify(value: str) -> str:
+    cleaned = re.sub(r"[^0-9A-Za-z]+", "_", value).strip("_")
+    if not cleaned:
+        cleaned = "TERM"
+    return cleaned.upper()
+
+
+__all__ = ["GroundedEntity", "GroundingResolver"]
+

--- a/backend/simulation/circuit.py
+++ b/backend/simulation/circuit.py
@@ -9,6 +9,7 @@ from typing import Dict, Mapping, Sequence, Tuple
 
 import numpy as np
 import numpy.typing as npt
+from scipy.integrate import solve_ivp
 
 from .assets import load_reference_connectivity
 
@@ -187,6 +188,71 @@ def _simulate_analytic(params: CircuitParameters, time: npt.NDArray[np.float64])
     return CircuitResponse(timepoints=time, region_activity=region_activity, global_metrics=summary, uncertainty=uncertainty)
 
 
+def _simulate_with_scipy(params: CircuitParameters, time: npt.NDArray[np.float64]) -> CircuitResponse:
+    if len(time) == 0:
+        raise ValueError("timepoints must contain at least one value")
+
+    regions = list(params.regions)
+    n_regions = len(regions)
+    if n_regions == 0:
+        raise ValueError("at least one region is required")
+
+    weights = np.zeros((n_regions, n_regions), dtype=float)
+    for (src, dst), value in params.connectivity.items():
+        try:
+            i = regions.index(src)
+            j = regions.index(dst)
+        except ValueError:
+            continue
+        weights[i, j] = float(value)
+
+    serotonin_drive = params.neuromodulator_drive.get("serotonin", 0.0)
+    dopamine_drive = params.neuromodulator_drive.get("dopamine", 0.0)
+    noradrenaline_drive = params.neuromodulator_drive.get("noradrenaline", 0.0)
+    drive_vector = np.full(n_regions, params.coupling_baseline, dtype=float)
+    drive_vector += 0.4 * serotonin_drive + 0.25 * dopamine_drive + 0.2 * noradrenaline_drive
+
+    def dynamics(_: float, state: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        coupling_term = weights @ state - np.sum(weights, axis=1) * state
+        damping = 0.1 + 0.05 * np.arange(n_regions)
+        return drive_vector + coupling_term - damping * state
+
+    solution = solve_ivp(
+        dynamics,
+        (float(time[0]), float(time[-1])),
+        y0=np.zeros(n_regions, dtype=float),
+        t_eval=time,
+        max_step=float(np.min(np.diff(time)) if time.size > 1 else 1.0),
+    )
+    if not solution.success:
+        raise RuntimeError(f"SciPy circuit solver failed: {solution.message}")
+
+    region_activity: Dict[str, npt.NDArray[np.float64]] = {}
+    for idx, region in enumerate(regions):
+        region_activity[region] = np.clip(solution.y[idx], 0.0, None).astype(float)
+
+    stacked = np.vstack(list(region_activity.values()))
+    mean_activity = stacked.mean(axis=0)
+    variance = stacked.var(axis=0)
+
+    drive_index = float(np.clip(mean_activity[-1] / (1.0 + mean_activity[-1]), 0.0, 1.0))
+    flexibility_index = float(np.clip(np.mean(variance) * 0.6, 0.0, 1.0))
+    anxiety_index = float(np.clip(0.4 - 0.25 * serotonin_drive + 0.15 * noradrenaline_drive, 0.0, 1.0))
+    apathy_index = float(np.clip(1.0 - drive_index * 0.9, 0.0, 1.0))
+
+    summary: Dict[str, float | str] = {
+        "drive_index": drive_index,
+        "flexibility_index": flexibility_index,
+        "anxiety_index": anxiety_index,
+        "apathy_index": apathy_index,
+        "backend": "scipy",
+    }
+    kg_conf = float(np.clip(params.kg_confidence, 0.0, 1.0))
+    uncertainty = {"network": float(max(0.05, 1.0 - kg_conf * 0.95))}
+
+    return CircuitResponse(timepoints=time, region_activity=region_activity, global_metrics=summary, uncertainty=uncertainty)
+
+
 def simulate_circuit_response(params: CircuitParameters) -> CircuitResponse:
     """Integrate a coarse network response with neuromodulator drives."""
 
@@ -205,7 +271,14 @@ def simulate_circuit_response(params: CircuitParameters) -> CircuitResponse:
         except Exception as exc:  # pragma: no cover - optional path
             LOGGER.debug("TVB backend unavailable (%s); falling back to analytic integrator", exc)
 
-    return _simulate_analytic(params, time)
+    if backend in {"scipy", "high_fidelity"}:
+        return _simulate_with_scipy(params, time)
+
+    try:
+        return _simulate_with_scipy(params, time)
+    except Exception as exc:  # pragma: no cover - defensive path
+        LOGGER.debug("SciPy circuit solver failed (%s); falling back to analytic response", exc)
+        return _simulate_analytic(params, time)
 
 
 __all__ = ["CircuitParameters", "CircuitResponse", "simulate_circuit_response", "HAS_TVB"]

--- a/backend/tests/test_gap_analysis.py
+++ b/backend/tests/test_gap_analysis.py
@@ -142,3 +142,5 @@ def test_gap_finder_persists_embeddings_in_vector_store() -> None:
     assert vector_store is not None
     if hasattr(vector_store, "_store"):
         assert vector_store._store.get("graph_nodes")  # type: ignore[attr-defined]
+    elif hasattr(vector_store, "path"):
+        assert vector_store.path.exists()  # type: ignore[attr-defined]

--- a/backend/tests/test_ingestion.py
+++ b/backend/tests/test_ingestion.py
@@ -78,8 +78,9 @@ def test_openalex_ingestion_creates_publication_and_author():
     # ensure DOI preserved in evidence annotations
     evidence_refs = [ev.reference for edge in edges for ev in edge.evidence if ev.reference]
     assert "10.1000/example" in evidence_refs
-    mined_edges = [edge for edge in edges if edge.predicate == BiolinkPredicate.AFFECTS and edge.subject.startswith("TXT:")]
+    mined_edges = [edge for edge in edges if edge.predicate == BiolinkPredicate.AFFECTS]
     assert mined_edges, "text-mining pipeline should add AFFECTS relation"
+    assert any(edge.subject.startswith("CHEBI:") for edge in mined_edges)
 
 
 def test_chembl_ingestion_interaction():

--- a/backend/tests/test_simulation_backends.py
+++ b/backend/tests/test_simulation_backends.py
@@ -202,38 +202,38 @@ def test_circuit_prefers_tvb_when_available(monkeypatch: pytest.MonkeyPatch, cir
     assert response.timepoints.shape[0] == circuit_params.timepoints.shape[0]
 
 
-def test_molecular_falls_back_to_analytic(monkeypatch: pytest.MonkeyPatch, cascade_params: MolecularCascadeParams) -> None:
+def test_molecular_falls_back_to_scipy(monkeypatch: pytest.MonkeyPatch, cascade_params: MolecularCascadeParams) -> None:
     monkeypatch.delenv("MOLECULAR_SIM_BACKEND", raising=False)
     monkeypatch.setattr(molecular, "Model", None, raising=False)
     monkeypatch.setattr(molecular, "HAS_PYSB", False, raising=False)
 
     result = molecular.simulate_cascade(cascade_params)
 
-    assert result.summary["backend"] == "analytic"
+    assert result.summary["backend"] == "scipy"
     assert set(result.node_activity) == set(cascade_params.downstream_nodes)
     assert all(np.all(node_activity >= 0.0) for node_activity in result.node_activity.values())
 
 
-def test_pkpd_falls_back_to_analytic(monkeypatch: pytest.MonkeyPatch, pkpd_params: PKPDParameters) -> None:
+def test_pkpd_falls_back_to_scipy(monkeypatch: pytest.MonkeyPatch, pkpd_params: PKPDParameters) -> None:
     monkeypatch.delenv("PKPD_SIM_BACKEND", raising=False)
     monkeypatch.setattr(pkpd, "HAS_OSPSUITE", False, raising=False)
     monkeypatch.setattr(pkpd, "ospsuite", None, raising=False)
 
     profile = pkpd.simulate_pkpd(pkpd_params)
 
-    assert profile.summary["backend"] == "analytic"
+    assert profile.summary["backend"] == "scipy"
     assert profile.timepoints[0] == pytest.approx(0.0)
     assert np.all(profile.plasma_concentration >= 0.0)
     assert np.all(profile.brain_concentration >= 0.0)
 
 
-def test_circuit_falls_back_to_analytic(monkeypatch: pytest.MonkeyPatch, circuit_params: CircuitParameters) -> None:
+def test_circuit_falls_back_to_scipy(monkeypatch: pytest.MonkeyPatch, circuit_params: CircuitParameters) -> None:
     monkeypatch.delenv("CIRCUIT_SIM_BACKEND", raising=False)
     monkeypatch.setattr(circuit, "HAS_TVB", False, raising=False)
     monkeypatch.setattr(circuit, "connectivity", None, raising=False)
 
     response = circuit.simulate_circuit_response(circuit_params)
 
-    assert response.global_metrics["backend"] == "analytic"
+    assert response.global_metrics["backend"] == "scipy"
     assert set(response.region_activity) == set(circuit_params.regions)
     assert response.timepoints.shape[0] == circuit_params.timepoints.shape[0]

--- a/backend/tests/test_simulation_engine.py
+++ b/backend/tests/test_simulation_engine.py
@@ -45,8 +45,8 @@ def test_engine_chronic_ssri_profile():
     assert result.scores["ApathyBlunting"] >= 0.0
     molecular_summary = result.module_summaries["molecular"]
     pkpd_summary = result.module_summaries["pkpd"]
-    assert molecular_summary["backend"] in {"analytic", "pysb"}
-    assert pkpd_summary["backend"] in {"analytic", "ospsuite"}
+    assert molecular_summary["backend"] in {"analytic", "pysb", "scipy"}
+    assert pkpd_summary["backend"] in {"analytic", "ospsuite", "scipy"}
     assert math.isfinite(molecular_summary["transient_peak"])
     assert math.isfinite(molecular_summary["steady_state"])
     assert math.isfinite(molecular_summary["activation_index"])

--- a/backend/tests/test_vector_store.py
+++ b/backend/tests/test_vector_store.py
@@ -1,5 +1,12 @@
 from backend.config import VectorStoreConfig
-from backend.graph.vector_store import InMemoryVectorStore, VectorRecord, build_vector_store
+from pathlib import Path
+
+from backend.graph.vector_store import (
+    InMemoryVectorStore,
+    SqliteVectorStore,
+    VectorRecord,
+    build_vector_store,
+)
 
 
 def test_inmemory_vector_store_queries_by_cosine_similarity() -> None:
@@ -19,4 +26,20 @@ def test_inmemory_vector_store_queries_by_cosine_similarity() -> None:
 def test_build_vector_store_falls_back_when_not_configured() -> None:
     config = VectorStoreConfig()
     store = build_vector_store(config)
-    assert isinstance(store, InMemoryVectorStore)
+    assert isinstance(store, SqliteVectorStore)
+
+
+def test_sqlite_vector_store_persists_between_instances(tmp_path) -> None:
+    db_path = tmp_path / "vectors.sqlite"
+    config = VectorStoreConfig(sqlite_path=str(db_path))
+    store = build_vector_store(config)
+    assert isinstance(store, SqliteVectorStore)
+    store.upsert(
+        "nodes",
+        [VectorRecord(id="A", vector=(0.5, 0.5), metadata={"node_id": "A"}, score=0.7)],
+    )
+    # Re-open to ensure persistence
+    store = build_vector_store(config)
+    results = store.query("nodes", (0.5, 0.5), top_k=1)
+    assert results and results[0].id == "A"
+    assert Path(db_path).exists()

--- a/frontend/src/__tests__/gap-dashboard.test.jsx
+++ b/frontend/src/__tests__/gap-dashboard.test.jsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import GapDashboard from '../components/GapDashboard'
+
+const SAMPLE_ITEMS = [
+  {
+    subject: 'CHEBI:28790',
+    object: 'HGNC:1033',
+    reason: 'Embedding model highlighted this relation as a likely gap. Context: human data.',
+    impact_score: 0.76,
+    embedding_score: 0.62,
+    metadata: { context_weight: 0.85, context_uncertainty: 0.4 },
+    literature: ['Example paper [W1]'],
+  },
+  {
+    subject: 'CHEBI:18243',
+    object: 'UBERON:0001870',
+    reason: 'Embedding model highlighted this relation as a likely gap. Context: limbic circuitry.',
+    impact_score: 0.64,
+    embedding_score: 0.58,
+    metadata: { context_weight: 0.7, context_uncertainty: 0.5 },
+    literature: [],
+  },
+]
+
+test('renders heatmap and detail panel for gaps', () => {
+  render(
+    <GapDashboard
+      onAnalyse={() => {}}
+      status="idle"
+      error={null}
+      items={SAMPLE_ITEMS}
+      suggestions={['CHEBI:28790', 'HGNC:1033']}
+    />,
+  )
+
+  expect(screen.getByText(/Ranked candidates/i)).toBeInTheDocument()
+  expect(screen.getByText(/Coverage heatmap/i)).toBeInTheDocument()
+  expect(screen.getByTestId('gap-detail')).toBeInTheDocument()
+
+  const [secondGap] = screen.getAllByText(/CHEBI:18243/i)
+  fireEvent.click(secondGap)
+  const detail = screen.getByTestId('gap-detail')
+  expect(within(detail).getByText(/UBERON:0001870/)).toBeInTheDocument()
+})

--- a/frontend/src/components/GapDashboard.css
+++ b/frontend/src/components/GapDashboard.css
@@ -1,27 +1,161 @@
+.gap-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1.3fr) minmax(0, 1fr);
+  gap: 1.25rem;
+  margin-top: 1.25rem;
+}
+
+.gap-list-wrapper,
+.gap-heatmap-wrapper,
+.gap-detail {
+  background: rgba(7, 12, 26, 0.82);
+  border-radius: 16px;
+  border: 1px solid rgba(94, 124, 196, 0.25);
+  padding: 1rem;
+  backdrop-filter: blur(6px);
+}
+
+.gap-list-wrapper h3,
+.gap-heatmap-wrapper h3,
+.gap-detail h3 {
+  margin-top: 0;
+  margin-bottom: 0.8rem;
+}
+
 .gap-list {
   margin: 0;
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 0.65rem;
+  gap: 0.6rem;
 }
 
 .gap-list li {
   background: rgba(18, 28, 50, 0.9);
   border-radius: 12px;
-  border: 1px solid rgba(94, 124, 196, 0.35);
+  border: 1px solid rgba(94, 124, 196, 0.25);
   padding: 0.6rem 0.85rem;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.gap-list li:hover,
+.gap-list li:focus {
+  border-color: rgba(130, 170, 255, 0.6);
+  transform: translateY(-1px);
+}
+
+.gap-list li.active {
+  border-color: rgba(170, 210, 255, 0.85);
+  box-shadow: 0 0 0 1px rgba(170, 210, 255, 0.35);
 }
 
 .gap-pair {
   font-weight: 600;
 }
 
+.gap-metrics {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: rgba(202, 220, 255, 0.85);
+}
+
 .gap-reason {
+  font-size: 0.82rem;
+  opacity: 0.7;
+}
+
+.heatmap-scroll {
+  overflow: auto;
+}
+
+.gap-heatmap {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 4px;
+  font-size: 0.75rem;
+}
+
+.gap-heatmap th,
+.gap-heatmap td {
+  text-align: center;
+  padding: 0.4rem;
+  min-width: 3.2rem;
+  border-radius: 8px;
+}
+
+.gap-heatmap th {
+  background: rgba(14, 22, 40, 0.95);
+  color: rgba(220, 232, 255, 0.85);
+  font-weight: 600;
+}
+
+.gap-heatmap td {
+  background: rgba(26, 36, 60, 0.6);
+  color: rgba(12, 21, 36, 0.95);
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+
+.gap-heatmap td.active {
+  outline: 2px solid rgba(255, 255, 255, 0.7);
+  transform: scale(1.02);
+}
+
+.gap-detail__title {
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.gap-detail__metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0 0 1rem;
+}
+
+.gap-detail__metrics dt {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(180, 198, 230, 0.75);
+}
+
+.gap-detail__metrics dd {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.gap-detail__reason {
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.gap-detail__literature ul {
+  margin: 0.4rem 0 1rem;
+  padding-left: 1.1rem;
   font-size: 0.8rem;
-  opacity: 0.65;
+}
+
+.gap-detail__causal {
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+@media (max-width: 1200px) {
+  .gap-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .gap-detail {
+    order: 3;
+  }
 }
 

--- a/frontend/src/components/GapDashboard.jsx
+++ b/frontend/src/components/GapDashboard.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import './GapDashboard.css'
 
@@ -9,8 +9,56 @@ function parseNodes(text) {
     .filter(Boolean)
 }
 
+function formatScore(value) {
+  if (value == null || Number.isNaN(value)) return '—'
+  return value.toFixed(2)
+}
+
+function deriveNodes(items) {
+  const ordered = []
+  const seen = new Set()
+  for (const gap of items) {
+    if (!seen.has(gap.subject)) {
+      ordered.push(gap.subject)
+      seen.add(gap.subject)
+    }
+    if (!seen.has(gap.object)) {
+      ordered.push(gap.object)
+      seen.add(gap.object)
+    }
+  }
+  return ordered.slice(0, 12)
+}
+
+function buildHeatmap(items) {
+  const nodes = deriveNodes(items)
+  const matrix = nodes.map((row) =>
+    nodes.map((column) =>
+      items.find((gap) => gap.subject === row && gap.object === column) || null,
+    ),
+  )
+  return { nodes, matrix }
+}
+
+function cellStyle(gap) {
+  if (!gap) return {}
+  const capped = Math.min(1, Math.max(0, gap.impact_score || gap.impact || 0))
+  const hue = 200 - capped * 120
+  const lightness = 80 - capped * 35
+  return { background: `hsl(${hue}, 75%, ${lightness}%)` }
+}
+
 export default function GapDashboard({ onAnalyse, status, error, items, suggestions }) {
   const [input, setInput] = useState(suggestions.join(', '))
+  const [selectedGap, setSelectedGap] = useState(null)
+
+  useEffect(() => {
+    if (items.length > 0) {
+      setSelectedGap(items[0])
+    } else {
+      setSelectedGap(null)
+    }
+  }, [items])
 
   const handleSubmit = (event) => {
     event.preventDefault()
@@ -20,6 +68,8 @@ export default function GapDashboard({ onAnalyse, status, error, items, suggesti
     }
     onAnalyse({ focus_nodes: nodes })
   }
+
+  const heatmap = useMemo(() => buildHeatmap(items), [items])
 
   return (
     <section className="panel" data-testid="gap-dashboard">
@@ -43,14 +93,107 @@ export default function GapDashboard({ onAnalyse, status, error, items, suggesti
       </form>
       {error && <p className="form-error" role="alert">{error.message}</p>}
       {items.length > 0 && (
-        <ul className="gap-list" data-testid="gap-results">
-          {items.map((gap) => (
-            <li key={`${gap.subject}-${gap.object}`}>
-              <span className="gap-pair">{gap.subject} → {gap.object}</span>
-              <span className="gap-reason">{gap.reason}</span>
-            </li>
-          ))}
-        </ul>
+        <div className="gap-layout">
+          <div className="gap-list-wrapper">
+            <h3>Ranked candidates</h3>
+            <ul className="gap-list" data-testid="gap-results">
+              {items.map((gap) => (
+                <li
+                  key={`${gap.subject}-${gap.object}`}
+                  className={selectedGap && selectedGap.subject === gap.subject && selectedGap.object === gap.object ? 'active' : ''}
+                  onClick={() => setSelectedGap(gap)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') setSelectedGap(gap)
+                  }}
+                  tabIndex={0}
+                  role="button"
+                >
+                  <span className="gap-pair">{gap.subject} → {gap.object}</span>
+                  <span className="gap-reason">{gap.reason}</span>
+                  <div className="gap-metrics">
+                    <span>Impact {formatScore(gap.impact_score || gap.impact)}</span>
+                    <span>Embedding {formatScore(gap.embedding_score)}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="gap-heatmap-wrapper">
+            <h3>Coverage heatmap</h3>
+            <div className="heatmap-scroll">
+              <table className="gap-heatmap">
+                <thead>
+                  <tr>
+                    <th aria-label="Empty" />
+                    {heatmap.nodes.map((node) => (
+                      <th key={`col-${node}`}>{node}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {heatmap.matrix.map((row, rowIndex) => (
+                    <tr key={heatmap.nodes[rowIndex]}>
+                      <th scope="row">{heatmap.nodes[rowIndex]}</th>
+                      {row.map((gap, columnIndex) => (
+                        <td
+                          key={`${rowIndex}-${columnIndex}`}
+                          style={cellStyle(gap)}
+                          className={gap && selectedGap && gap.subject === selectedGap.subject && gap.object === selectedGap.object ? 'active' : ''}
+                          onClick={() => gap && setSelectedGap(gap)}
+                        >
+                          {gap ? formatScore(gap.impact_score || gap.impact) : ''}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+          {selectedGap && (
+            <aside className="gap-detail" data-testid="gap-detail">
+              <h3>Gap triage</h3>
+              <p className="gap-detail__title">
+                <strong>{selectedGap.subject}</strong> → <strong>{selectedGap.object}</strong>
+              </p>
+              <dl className="gap-detail__metrics">
+                <div>
+                  <dt>Impact score</dt>
+                  <dd>{formatScore(selectedGap.impact_score || selectedGap.impact)}</dd>
+                </div>
+                <div>
+                  <dt>Embedding score</dt>
+                  <dd>{formatScore(selectedGap.embedding_score)}</dd>
+                </div>
+                <div>
+                  <dt>Context weight</dt>
+                  <dd>{formatScore(selectedGap.metadata?.context_weight)}</dd>
+                </div>
+                <div>
+                  <dt>Uncertainty</dt>
+                  <dd>{formatScore(selectedGap.metadata?.context_uncertainty)}</dd>
+                </div>
+              </dl>
+              {selectedGap.reason && <p className="gap-detail__reason">{selectedGap.reason}</p>}
+              {selectedGap.literature && selectedGap.literature.length > 0 && (
+                <div className="gap-detail__literature">
+                  <h4>Suggested literature</h4>
+                  <ul>
+                    {selectedGap.literature.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {selectedGap.causal && (
+                <div className="gap-detail__causal">
+                  <h4>Causal summary</h4>
+                  <p>{selectedGap.causal.description}</p>
+                </div>
+              )}
+            </aside>
+          )}
+        </div>
       )}
     </section>
   )
@@ -65,6 +208,14 @@ GapDashboard.propTypes = {
       subject: PropTypes.string.isRequired,
       object: PropTypes.string.isRequired,
       reason: PropTypes.string,
+      impact_score: PropTypes.number,
+      impact: PropTypes.number,
+      embedding_score: PropTypes.number,
+      metadata: PropTypes.object,
+      literature: PropTypes.arrayOf(PropTypes.string),
+      causal: PropTypes.shape({
+        description: PropTypes.string,
+      }),
     }),
   ),
   suggestions: PropTypes.arrayOf(PropTypes.string),


### PR DESCRIPTION
## Summary
- add a curated grounding resolver and richer evidence assembly to the literature text-mining pipeline so mined entities map onto stable Biolink identifiers
- persist graph embeddings via a file-backed SQLite vector store when pgvector is not configured and upgrade the built-in SciPy simulators for molecular, PK/PD, and circuit layers
- expand the gap triage dashboard with a ranked list, impact heatmap, and detail inspector backed by new frontend tests

## Testing
- python -m compileall backend/main.py
- pytest
- npm test -- --watch=false
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d476cc3318832982cfc22c23d0ac50