### PR TITLE
Add assistant gateway endpoints for agent integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,34 @@ uvicorn backend.main:app --host 0.0.0.0 --port 8000
 The base requirements now ship with the Neo4j (5.x) and python-arango clients so
 managed Aura and Oasis endpoints work without extra installs.
 
+#### Programmatic assistant gateway
+
+Custom GPTs and other agent-style clients can call the API through a single
+entrypoint without hand-coding each workflow. Two new endpoints surface the
+available actions and execute them on behalf of the caller:
+
+```text
+GET  /assistant/capabilities   # Lists supported actions + JSON Schemas
+POST /assistant/execute        # Dispatches an action with a validated payload
+```
+
+For example, predicting receptor evidence reduces to:
+
+```bash
+curl -X POST http://localhost:8000/assistant/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+        "action": "predict_effects",
+        "payload": {"receptors": [{"name": "5HT1A"}]}
+      }'
+```
+
+The response bundles the underlying REST endpoint, a normalised payload and the
+result body so agent frameworks can reason over inputs and outputs with minimal
+custom code. This gateway works transparently behind the provided Cloudflare
+Worker proxy and can be deployed to a FastAPI-ready Hugging Face Space by
+pointing `app = backend.main.app` inside your Space entry script.
+
 The optional simulation toolkits (PySB, OSPSuite, TVB) pull heavy native wheels.
 Install them only when you need the full PK/PD stack:
 

--- a/backend/tests/test_api_assistant_gateway.py
+++ b/backend/tests/test_api_assistant_gateway.py
@@ -1,0 +1,58 @@
+"""Integration tests covering the assistant aggregation endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend.main import app
+
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+@pytest.fixture()
+async def client():
+    """Provide an async HTTP client bound to the FastAPI app."""
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as instance:
+        yield instance
+
+
+@pytest.fixture()
+def anyio_backend():
+    return "asyncio"
+
+
+async def test_assistant_capabilities_exposes_actions(client):
+    response = await client.get("/assistant/capabilities")
+    assert response.status_code == 200
+    data = response.json()
+    actions = {item["action"] for item in data["actions"]}
+    assert "predict_effects" in actions
+    assert "simulate" in actions
+    effect_entry = next(item for item in data["actions"] if item["action"] == "predict_effects")
+    assert effect_entry["endpoint"] == "/predict/effects"
+    assert effect_entry["payload_schema"]["type"] == "object"
+
+
+async def test_assistant_execute_predict_effects(serotonin_graph, client):
+    payload = {"action": "predict_effects", "payload": {"receptors": [{"name": "5HT1A"}]}}
+    response = await client.post("/assistant/execute", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["action"] == "predict_effects"
+    assert data["source_endpoint"] == "/predict/effects"
+    effect = data["result"]["items"][0]
+    assert effect["receptor"] == "5-HT1A"
+    assert data["normalized_payload"]["receptors"][0]["name"] == "5HT1A"
+
+
+async def test_assistant_execute_reports_validation_errors(client):
+    response = await client.post("/assistant/execute", json={"action": "atlas_overlay", "payload": {}})
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["code"] == "invalid_payload"
+    first_error = detail["context"]["errors"][0]
+    assert first_error["loc"][-1] == "node_id"


### PR DESCRIPTION
## Summary
- add an assistant gateway that exposes `/assistant/capabilities` and `/assistant/execute` for GPT-style clients
- extend API schemas with assistant request/response models and an atlas overlay request envelope
- document the new entrypoints and add integration tests covering assistant workflows

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4938477c88329bcfe767edb1b6f8f