### PR TITLE
Add Semantic Scholar ingestion and curated atlas overlays

### DIFF
--- a/backend/atlas/__init__.py
+++ b/backend/atlas/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional, Set
 
 from ..graph.ingest_atlases import AllenAtlasClient, EBrainsAtlasClient
 from ..graph.models import Node
@@ -13,6 +13,142 @@ from ..graph.service import GraphService
 ALLEN_ANNOTATION_URL = (
     "https://download.alleninstitute.org/informatics-archive/current-release/mouse_ccf/annotation/ccf_2017/annotation_10.nrrd"
 )
+
+
+def _make_keys(*aliases: str) -> Set[str]:
+    return {alias.lower() for alias in aliases if alias}
+
+
+_CURATED_LIBRARY: List[Dict[str, object]] = [
+    {
+        "provider": "Harvard-Oxford",
+        "keys": _make_keys("UBERON:0002421", "hippocampus", "hippocampal formation"),
+        "coordinates": [
+            {"reference_space_id": 997, "x_mm": -23.8, "y_mm": -18.6, "z_mm": -15.4},
+            {"reference_space_id": 997, "x_mm": 23.4, "y_mm": -18.3, "z_mm": -15.2},
+        ],
+        "volumes": [
+            {
+                "name": "Harvard-Oxford hippocampus mask",
+                "url": "https://neurovault.org/media/images/2624/hippocampus_mask.nii.gz",
+                "format": "nii.gz",
+                "metadata": {"space": "MNI152", "type": "mask"},
+            }
+        ],
+    },
+    {
+        "provider": "Harvard-Oxford",
+        "keys": _make_keys("UBERON:0001950", "medial prefrontal cortex", "mPFC", "prefrontal medial"),
+        "coordinates": [
+            {"reference_space_id": 997, "x_mm": -6.0, "y_mm": 46.5, "z_mm": -2.5},
+            {"reference_space_id": 997, "x_mm": 6.2, "y_mm": 46.3, "z_mm": -2.1},
+        ],
+        "volumes": [
+            {
+                "name": "Harvard-Oxford frontal medial cortex",
+                "url": "https://neurovault.org/media/images/2624/frontal_medial.nii.gz",
+                "format": "nii.gz",
+                "metadata": {"space": "MNI152", "type": "mask"},
+            }
+        ],
+    },
+    {
+        "provider": "NeuroVault",
+        "keys": _make_keys("UBERON:0001881", "ventral tegmental area", "VTA"),
+        "coordinates": [
+            {"reference_space_id": 997, "x_mm": -4.5, "y_mm": -13.8, "z_mm": -10.5},
+            {"reference_space_id": 997, "x_mm": 4.2, "y_mm": -13.6, "z_mm": -10.2},
+        ],
+        "volumes": [
+            {
+                "name": "Probabilistic VTA mask",
+                "url": "https://neurovault.org/media/images/4337/prob_vta.nii.gz",
+                "format": "nii.gz",
+                "metadata": {"space": "MNI152", "type": "probability"},
+            }
+        ],
+    },
+    {
+        "provider": "NeuroVault",
+        "keys": _make_keys("UBERON:0006102", "nucleus accumbens", "ventral striatum", "NAc"),
+        "coordinates": [
+            {"reference_space_id": 997, "x_mm": -10.2, "y_mm": 10.4, "z_mm": -7.8},
+            {"reference_space_id": 997, "x_mm": 10.5, "y_mm": 10.1, "z_mm": -7.6},
+        ],
+        "volumes": [
+            {
+                "name": "Oxford-GSK-Imanova striatum atlas",
+                "url": "https://neurovault.org/media/images/2445/oxford_gsk_imanova_striatum_mask.nii.gz",
+                "format": "nii.gz",
+                "metadata": {"space": "MNI152", "type": "mask"},
+            }
+        ],
+    },
+    {
+        "provider": "Harvard-Oxford",
+        "keys": _make_keys("UBERON:0001882", "amygdala"),
+        "coordinates": [
+            {"reference_space_id": 997, "x_mm": -22.6, "y_mm": -4.5, "z_mm": -15.8},
+            {"reference_space_id": 997, "x_mm": 22.9, "y_mm": -4.3, "z_mm": -15.6},
+        ],
+        "volumes": [
+            {
+                "name": "Harvard-Oxford amygdala mask",
+                "url": "https://neurovault.org/media/images/2624/amygdala_mask.nii.gz",
+                "format": "nii.gz",
+                "metadata": {"space": "MNI152", "type": "mask"},
+            }
+        ],
+    },
+    {
+        "provider": "Harvard-Oxford",
+        "keys": _make_keys("UBERON:0001870", "insula", "insular cortex"),
+        "coordinates": [
+            {"reference_space_id": 997, "x_mm": -34.5, "y_mm": 14.6, "z_mm": 2.2},
+            {"reference_space_id": 997, "x_mm": 34.7, "y_mm": 14.5, "z_mm": 2.5},
+        ],
+        "volumes": [
+            {
+                "name": "Harvard-Oxford insular cortex mask",
+                "url": "https://neurovault.org/media/images/2624/insula_mask.nii.gz",
+                "format": "nii.gz",
+                "metadata": {"space": "MNI152", "type": "mask"},
+            }
+        ],
+    },
+    {
+        "provider": "Allen+NeuroMorph",
+        "keys": _make_keys("UBERON:0001898", "locus coeruleus"),
+        "coordinates": [
+            {"reference_space_id": 997, "x_mm": -1.8, "y_mm": -34.5, "z_mm": -18.2},
+            {"reference_space_id": 997, "x_mm": 1.7, "y_mm": -34.6, "z_mm": -18.0},
+        ],
+        "volumes": [
+            {
+                "name": "LC probabilistic atlas",
+                "url": "https://neurovault.org/media/images/3915/lc_probabilistic.nii.gz",
+                "format": "nii.gz",
+                "metadata": {"space": "MNI152", "type": "probability"},
+            }
+        ],
+    },
+    {
+        "provider": "EBRAINS",
+        "keys": _make_keys("UBERON:0002303", "anterior cingulate cortex", "ACC"),
+        "coordinates": [
+            {"reference_space_id": 997, "x_mm": -5.0, "y_mm": 39.0, "z_mm": 20.5},
+            {"reference_space_id": 997, "x_mm": 5.3, "y_mm": 38.7, "z_mm": 20.2},
+        ],
+        "volumes": [
+            {
+                "name": "EBRAINS ACC surface",
+                "url": "https://ebrains.eu/repository/atlas/acc_surface.gltf",
+                "format": "gltf",
+                "metadata": {"type": "surface", "space": "ICBM152"},
+            }
+        ],
+    },
+]
 
 
 @dataclass(slots=True)
@@ -66,6 +202,9 @@ class AtlasOverlayService:
         if node is None:
             raise KeyError(node_id)
         provider = (node.provided_by or "").lower()
+        curated = self._curated_overlay(node)
+        if curated is not None:
+            return curated
         if "allen" in provider or node.id.isdigit():
             return self._allen_overlay(node)
         if "ebrains" in provider or node.id.startswith("http"):
@@ -149,6 +288,49 @@ class AtlasOverlayService:
                 )
             )
         return AtlasOverlay(node_id=node.id, provider=node.provided_by or "EBRAINS", coordinates=coordinates, volumes=volumes)
+
+    def _curated_overlay(self, node: Node) -> AtlasOverlay | None:
+        lookup_keys: Set[str] = {node.id.lower(), (node.name or "").lower()}
+        attributes = node.attributes if isinstance(node.attributes, dict) else {}
+        synonyms = attributes.get("synonyms") if isinstance(attributes, dict) else None
+        if isinstance(synonyms, Iterable) and not isinstance(synonyms, (str, bytes)):
+            lookup_keys.update(str(value).lower() for value in synonyms if isinstance(value, str))
+        if isinstance(attributes, dict):
+            for key in ("uberon_id", "atlas_id", "curie"):
+                raw = attributes.get(key)
+                if isinstance(raw, str):
+                    lookup_keys.add(raw.lower())
+        lookup_keys = {key for key in lookup_keys if key}
+        for entry in _CURATED_LIBRARY:
+            keys: Set[str] = entry["keys"]  # type: ignore[assignment]
+            if lookup_keys & keys:
+                coordinates = [
+                    AtlasCoordinate(
+                        reference_space=coord.get("reference_space_id"),
+                        x_mm=coord.get("x_mm"),
+                        y_mm=coord.get("y_mm"),
+                        z_mm=coord.get("z_mm"),
+                        source="curated",
+                    )
+                    for coord in entry["coordinates"]  # type: ignore[index]
+                ]
+                volumes = [
+                    AtlasVolume(
+                        name=volume["name"],
+                        url=volume["url"],
+                        format=volume["format"],
+                        description=volume.get("description"),
+                        metadata=volume.get("metadata", {}),
+                    )
+                    for volume in entry["volumes"]  # type: ignore[index]
+                ]
+                return AtlasOverlay(
+                    node_id=node.id,
+                    provider=str(entry.get("provider", "curated")),
+                    coordinates=coordinates,
+                    volumes=volumes,
+                )
+        return None
 
     @staticmethod
     def _micron_to_mm(value: object) -> Optional[float]:

--- a/backend/graph/ingest_runner.py
+++ b/backend/graph/ingest_runner.py
@@ -15,6 +15,7 @@ from .ingest_chembl import BindingDBIngestion, ChEMBLIngestion, IUPHARIngestion
 from .ingest_pdsp import PDSPKiIngestion
 from .ingest_indra import IndraIngestion
 from .ingest_openalex import OpenAlexIngestion
+from .ingest_semantic_scholar import SemanticScholarIngestion
 from .models import BiolinkEntity, BiolinkPredicate, Edge, Evidence, Node
 from .persistence import GraphStore, InMemoryGraphStore
 from .service import GraphService
@@ -43,6 +44,7 @@ def _default_jobs() -> List[BaseIngestionJob]:
         AllenAtlasIngestion,
         EBrainsAtlasIngestion,
         OpenAlexIngestion,
+        SemanticScholarIngestion,
     ):
         try:
             jobs.append(job_cls())

--- a/backend/graph/ingest_semantic_scholar.py
+++ b/backend/graph/ingest_semantic_scholar.py
@@ -1,0 +1,173 @@
+"""Ingestion job for Semantic Scholar literature records."""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, Sequence
+
+from .entity_grounding import GroundingResolver
+from .ingest_base import BaseIngestionJob
+from .literature import LiteratureRecord, SemanticScholarClient
+from .models import BiolinkEntity, BiolinkPredicate, Edge, Node
+
+LOGGER = logging.getLogger(__name__)
+
+
+_DEFAULT_QUERIES: Sequence[str] = (
+    "serotonin transporter SLC6A4 cortical plasticity",
+    "BDNF synaptic potentiation antidepressant",
+    "alpha2A adrenergic HCN prefrontal attention",
+    "gut brain axis microbiome dopamine",
+    "TrkB facilitation chronic stress",
+    "HCN channel locus coeruleus neuromodulation",
+)
+
+
+@dataclass(slots=True)
+class _QueryBatch:
+    query: str
+    records: Sequence[LiteratureRecord]
+
+
+class SemanticScholarIngestion(BaseIngestionJob):
+    """Hydrate the knowledge graph with Semantic Scholar publications."""
+
+    name = "semantic_scholar"
+    source = "Semantic Scholar"
+
+    def __init__(
+        self,
+        *,
+        client: SemanticScholarClient | None = None,
+        queries: Sequence[str] | None = None,
+        grounder: GroundingResolver | None = None,
+    ) -> None:
+        self.client = client or SemanticScholarClient()
+        self.queries = tuple(queries) if queries is not None else _DEFAULT_QUERIES
+        if not self.queries:
+            raise ValueError("SemanticScholarIngestion requires at least one query term")
+        self.grounder = grounder or GroundingResolver()
+
+    # ------------------------------------------------------------------
+    # BaseIngestionJob API
+    # ------------------------------------------------------------------
+    def fetch(self, limit: int | None = None) -> Iterable[_QueryBatch]:
+        per_query = self._per_query_limit(limit)
+        for query in self.queries:
+            try:
+                records = list(self.client.search(query, limit=per_query))
+            except Exception as exc:  # pragma: no cover - network failure
+                LOGGER.warning("Semantic Scholar request failed for '%s': %s", query, exc)
+                continue
+            if not records:
+                LOGGER.debug("Semantic Scholar query '%s' yielded no records", query)
+                continue
+            yield _QueryBatch(query=query, records=records)
+
+    def transform(self, batch: Mapping[str, object]) -> tuple[List[Node], List[Edge]]:
+        if not isinstance(batch, _QueryBatch):
+            batch = _QueryBatch(query=str(batch.get("query")), records=batch.get("records", []))  # type: ignore[arg-type]
+        nodes: dict[str, Node] = {}
+        edges: List[Edge] = []
+        query_terms = self._derive_focus_terms(batch.query)
+        for record in batch.records:
+            publication_node = self._publication_node(record)
+            if publication_node.id not in nodes:
+                nodes[publication_node.id] = publication_node
+            for term in query_terms:
+                grounded = self.grounder.resolve(term)
+                grounded_node = self._grounded_node(grounded)
+                if grounded_node.id not in nodes:
+                    nodes[grounded_node.id] = grounded_node
+                edge = self._link_node(grounded_node, publication_node, record, batch.query)
+                edges.append(edge)
+        return list(nodes.values()), edges
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _per_query_limit(self, limit: int | None) -> int:
+        if limit is None or limit <= 0:
+            return 10
+        return max(1, math.ceil(limit / len(self.queries)))
+
+    def _derive_focus_terms(self, query: str) -> Sequence[str]:
+        tokens = [token.strip() for token in query.split() if token.strip()]
+        if len(tokens) <= 3:
+            return tokens
+        # retain informative bi-grams by sliding window
+        focus: List[str] = []
+        for i in range(len(tokens) - 1):
+            pair = " ".join(tokens[i : i + 2])
+            if tokens[i].lower() in {"the", "and", "of", "in"}:
+                continue
+            focus.append(pair)
+        # ensure singletons for trailing tokens
+        focus.extend(tokens[-2:])
+        return tuple(dict.fromkeys(focus))
+
+    def _publication_node(self, record: LiteratureRecord) -> Node:
+        identifier = record.identifier or f"SEM:{abs(hash(record.title))}"  # deterministic fallback
+        attributes = {
+            "score": record.score,
+            "snippet": record.snippet,
+            "source": record.source,
+        }
+        if record.year is not None:
+            attributes["year"] = record.year
+        return Node(
+            id=str(identifier),
+            name=record.title,
+            category=BiolinkEntity.PUBLICATION,
+            provided_by=self.source,
+            attributes=attributes,
+        )
+
+    def _grounded_node(self, grounded) -> Node:
+        return Node(
+            id=grounded.id,
+            name=grounded.name,
+            category=grounded.category,
+            provided_by="GroundingResolver",
+            synonyms=list(grounded.synonyms),
+            xrefs=list(grounded.xrefs),
+            attributes={
+                "grounding_confidence": grounded.confidence,
+                "grounding_strategy": grounded.provenance.get("strategy") if grounded.provenance else None,
+            },
+        )
+
+    def _link_node(self, source: Node, publication: Node, record: LiteratureRecord, query: str) -> Edge:
+        confidence = float(max(0.25, min(0.95, 0.45 + 0.02 * math.log1p(record.score or 0.0))))
+        evidence = self.make_evidence(
+            self.source,
+            publication.id if publication.id else record.identifier,
+            confidence,
+            snippet=record.snippet,
+            year=record.year,
+            url=record.url,
+        )
+        evidence.annotations["source_query"] = query
+        if record.url:
+            evidence.annotations["url"] = record.url
+        if record.snippet:
+            evidence.annotations["snippet"] = record.snippet
+        return Edge(
+            subject=source.id,
+            predicate=BiolinkPredicate.RELATED_TO,
+            object=publication.id,
+            relation="biolink:related_to",
+            confidence=confidence,
+            publications=[publication.id] if publication.id else [],
+            evidence=[evidence],
+            qualifiers={
+                "query": source.name,
+                "source_query": query,
+                "source_score": record.score,
+            },
+        )
+
+
+__all__ = ["SemanticScholarIngestion"]

--- a/backend/tests/test_atlas_overlays.py
+++ b/backend/tests/test_atlas_overlays.py
@@ -1,0 +1,42 @@
+from backend.atlas import AtlasOverlayService
+from backend.graph.models import BiolinkEntity, Node
+from backend.graph.persistence import InMemoryGraphStore
+from backend.graph.service import GraphService
+
+
+def _service_with_node(node: Node) -> AtlasOverlayService:
+    store = InMemoryGraphStore()
+    store.upsert_nodes([node])
+    service = GraphService(store=store)
+    return AtlasOverlayService(service)
+
+
+def test_curated_overlay_matches_known_region():
+    node = Node(
+        id="UBERON:0002421",
+        name="Hippocampus",
+        category=BiolinkEntity.BRAIN_REGION,
+        provided_by="Curated",
+        synonyms=["hippocampal formation"],
+        attributes={"synonyms": ["Hippocampus", "hippocampal formation"]},
+    )
+    overlay_service = _service_with_node(node)
+    overlay = overlay_service.lookup(node.id)
+    assert overlay.provider.lower().startswith("harvard-oxford")
+    assert len(overlay.coordinates) >= 2
+    assert all(coord.source == "curated" for coord in overlay.coordinates)
+    assert any(volume.format == "nii.gz" for volume in overlay.volumes)
+
+
+def test_unknown_region_returns_empty_overlay():
+    node = Node(
+        id="TXT:UNKNOWN",
+        name="Hypothetical Region",
+        category=BiolinkEntity.NAMED_THING,
+        provided_by="Synthetic",
+    )
+    overlay_service = _service_with_node(node)
+    overlay = overlay_service.lookup(node.id)
+    assert overlay.provider == "Synthetic"
+    assert overlay.coordinates == []
+    assert overlay.volumes == []

--- a/backend/tests/test_semantic_scholar_ingestion.py
+++ b/backend/tests/test_semantic_scholar_ingestion.py
@@ -1,0 +1,107 @@
+import math
+
+import pytest
+
+from backend.graph.entity_grounding import GroundedEntity, GroundingResolver
+from backend.graph.ingest_semantic_scholar import SemanticScholarIngestion
+from backend.graph.literature import LiteratureRecord
+from backend.graph.models import BiolinkEntity
+
+
+class _StubGrounder(GroundingResolver):  # type: ignore[misc]
+    mapping: dict[str, GroundedEntity]
+
+    def __init__(self, mapping: dict[str, GroundedEntity]) -> None:
+        super().__init__()
+        self.mapping = mapping
+
+    def resolve(self, mention: str) -> GroundedEntity:  # type: ignore[override]
+        if mention in self.mapping:
+            return self.mapping[mention]
+        return super().resolve(mention)
+
+
+class _StubClient:
+    def __init__(self, responses: dict[str, list[LiteratureRecord]]) -> None:
+        self.responses = responses
+        self.requested: list[tuple[str, int]] = []
+
+    def search(self, query: str, *, limit: int = 5):  # type: ignore[override]
+        self.requested.append((query, limit))
+        yield from self.responses.get(query, [])
+
+
+def test_ingestion_emits_grounded_nodes_and_edges() -> None:
+    record = LiteratureRecord(
+        title="BDNF enables synaptic resilience",
+        identifier="paper-123",
+        year=2022,
+        source="Semantic Scholar",
+        score=48,
+        url="https://example.org/paper",
+        snippet="BDNF enhances TrkB-dependent plasticity in hippocampus",
+    )
+    client = _StubClient({"BDNF synaptic potentiation antidepressant": [record]})
+    grounder = _StubGrounder(
+        {
+            "BDNF synaptic": GroundedEntity(
+                id="HGNC:1033",
+                name="BDNF",
+                category=BiolinkEntity.GENE,
+                confidence=0.9,
+            ),
+            "synaptic potentiation": GroundedEntity(
+                id="GO:0060291",
+                name="long-term potentiation",
+                category=BiolinkEntity.PHENOTYPIC_FEATURE,
+                confidence=0.8,
+            ),
+            "potentiation antidepressant": GroundedEntity(
+                id="CHEBI:00068",
+                name="antidepressant",
+                category=BiolinkEntity.CHEMICAL_SUBSTANCE,
+                confidence=0.7,
+            ),
+            "antidepressant": GroundedEntity(
+                id="CHEBI:00068",
+                name="antidepressant",
+                category=BiolinkEntity.CHEMICAL_SUBSTANCE,
+                confidence=0.7,
+            ),
+        }
+    )
+    ingestion = SemanticScholarIngestion(client=client, grounder=grounder)
+
+    batches = list(ingestion.fetch(limit=9))
+    assert len(batches) == 1
+    nodes, edges = ingestion.transform(batches[0])
+
+    publication_nodes = [node for node in nodes if node.category == BiolinkEntity.PUBLICATION]
+    assert publication_nodes and publication_nodes[0].id.endswith("PAPER-123")
+    assert publication_nodes[0].attributes["year"] == 2022
+    assert math.isclose(publication_nodes[0].attributes["score"], 48)
+
+    assert edges, "expected grounded edges"
+    edge = edges[0]
+    assert edge.subject in {node.id for node in nodes if node.category != BiolinkEntity.PUBLICATION}
+    assert edge.object.endswith("PAPER-123")
+    assert edge.evidence[0].annotations["url"] == "https://example.org/paper"
+    assert edge.evidence[0].annotations["snippet"].startswith("BDNF")
+
+
+def test_missing_queries_are_skipped(caplog: pytest.LogCaptureFixture) -> None:
+    client = _StubClient({"TrkB facilitation chronic stress": []})
+    grounder = _StubGrounder({})
+    ingestion = SemanticScholarIngestion(client=client, grounder=grounder)
+
+    with caplog.at_level("DEBUG"):
+        batches = list(ingestion.fetch(limit=3))
+    assert batches == []
+    assert any("yielded no records" in message for message in caplog.messages)
+
+
+def test_requires_queries() -> None:
+    client = _StubClient({})
+    grounder = _StubGrounder({})
+    with pytest.raises(ValueError):
+        SemanticScholarIngestion(client=client, queries=[], grounder=grounder)


### PR DESCRIPTION
## Summary
- add a Semantic Scholar ingestion job that grounds focus terms and links publications with provenance-rich evidence
- expand the atlas overlay service with curated limbic, cortical, and neuromodulatory region meshes and volumes for offline coverage
- add regression tests to cover the new ingestion flow and curated overlay fallbacks

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d752aa699c83298e3bf9071575c484