### PR TITLE
Add MCP CLI bridge and documentation

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -103,3 +103,14 @@ For each execution action, send a JSON body shaped like:
 ```
 
 The backend validates the payload, executes the workflow, and returns structured JSON containing the normalised input plus the result data—no manual parsing required.
+
+---
+
+## Optional: orchestrate everything from the MCP CLI
+
+If you prefer a command-line control plane, the repository now includes an MCP
+bridge that forwards requests from [`mcp-cli`](https://github.com/chrishayuk/mcp-cli)
+to your Render service, Cloudflare Worker, or Hugging Face Space. Follow the
+step-by-step instructions in `docs/mcp-cli.md` to install the CLI, export your
+deployment URLs, and launch an interactive session that can trigger any of the
+assistant workflows without leaving the terminal.【F:docs/mcp-cli.md†L1-L92】

--- a/docs/mcp-cli.md
+++ b/docs/mcp-cli.md
@@ -1,0 +1,101 @@
+# Using the MCP CLI with Neuropharm Simulation Lab
+
+This guide shows how to drive the Neuropharm Simulation Lab deployments (Render,
+Cloudflare Worker, and Hugging Face Space) from the open-source
+[`mcp-cli`](https://github.com/chrishayuk/mcp-cli) tooling. The repository ships a
+ready-to-run MCP bridge that proxies HTTP requests to the deployed FastAPI
+backend so that `mcp-cli` can call the same workflows your Render service
+exposes.
+
+## 1. Install the MCP tooling
+
+Create a clean virtual environment and install the helper dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r infra/mcp/requirements.txt
+```
+
+The requirements file pins compatible versions of `mcp`, `mcp-cli`, and the
+HTTP client used by the bridge server.【F:infra/mcp/requirements.txt†L1-L4】
+
+## 2. Configure deployment endpoints
+
+Export the URLs for every deployment you want to route through the bridge.
+You can set as many as you need—Render, the Cloudflare Worker fronting KV/D1,
+and a Hugging Face Space are all supported out of the box.【F:infra/mcp/render_bridge.py†L24-L59】
+
+```bash
+export NEUROPHARM_RENDER_URL="https://<your-render-service>.onrender.com"
+export NEUROPHARM_WORKER_URL="https://<your-worker-subdomain>.workers.dev"
+export NEUROPHARM_HF_URL="https://<your-space>.hf.space"
+export NEUROPHARM_DEFAULT_TARGET=worker   # optional, defaults to the first configured URL
+```
+
+If a deployment requires authentication, provide an API key using one of the
+optional environment variables listed below:
+
+| Purpose | Environment variable | Notes |
+| --- | --- | --- |
+| Shared Authorization header | `NEUROPHARM_API_KEY` | Applied to every target unless overridden. |
+| Render-specific token | `NEUROPHARM_RENDER_API_KEY` | Overrides the shared key when calling Render. |
+| Cloudflare Worker token | `NEUROPHARM_WORKER_API_KEY` | Useful when the Worker enforces bearer auth. |
+| Extra headers (JSON) | `NEUROPHARM_EXTRA_HEADERS_JSON` | JSON object of additional headers (e.g. `{"CF-Worker": "edge"}`). |
+
+All variables are consumed by the bridge before each request so you can adjust
+them without restarting `mcp-cli`.【F:infra/mcp/render_bridge.py†L61-L119】
+
+## 3. Point `mcp-cli` at the bridge
+
+Copy the provided configuration template to a location that `mcp-cli` can read
+(such as `~/.config/mcp-cli/server_config.json`) and replace the placeholder URLs
+with your deployment endpoints.【F:infra/mcp/server_config.json†L1-L15】
+
+```bash
+mkdir -p ~/.config/mcp-cli
+cp infra/mcp/server_config.json ~/.config/mcp-cli/server_config.json
+$EDITOR ~/.config/mcp-cli/server_config.json
+```
+
+The template already wires the `neuropharm-render` server entry to run the bridge
+via `python -m infra.mcp.render_bridge`. If you prefer to keep the configuration
+inside the repository, pass `--config-file infra/mcp/server_config.json` to every
+`mcp-cli` command instead of copying the file.
+
+## 4. Launch the bridge and start chatting
+
+With the environment variables set, start an interactive MCP session that uses
+the Worker URL by default:
+
+```bash
+mcp-cli chat --server neuropharm-render \
+  --config-file infra/mcp/server_config.json \
+  --provider openai --model gpt-4o-mini
+```
+
+During the session you can:
+
+- Run `/tools` to list the available helpers (`neuropharm.list_targets`,
+  `neuropharm.fetch_capabilities`, `neuropharm.execute_action`, and
+  `neuropharm.raw_request`).【F:infra/mcp/render_bridge.py†L121-L173】
+- Execute a workflow from the Render backend:
+  `/cmd neuropharm.execute_action action=simulate payload='{"dose_mg": 20}'`
+- Switch targets at runtime by passing `target="render"` (Render service) or
+  `target="huggingface"` when calling a tool.【F:infra/mcp/render_bridge.py†L78-L173】
+
+Every tool response includes the upstream URL, HTTP status, a parsed JSON body
+(if available), and the headers that are useful for debugging cache hits coming
+from Cloudflare.【F:infra/mcp/render_bridge.py†L101-L112】
+
+## 5. Troubleshooting tips
+
+| Symptom | Fix |
+| --- | --- |
+| `Unknown target 'worker'` errors | Ensure `NEUROPHARM_WORKER_URL` is exported before launching the bridge.【F:infra/mcp/render_bridge.py†L31-L47】 |
+| Authentication failures | Double-check the relevant `NEUROPHARM_*_API_KEY` value or inspect the returned headers for clues.【F:infra/mcp/render_bridge.py†L80-L114】 |
+| Timeouts on heavy workflows | Increase `NEUROPHARM_MCP_TIMEOUT` or pass `timeout_seconds` when invoking a tool.【F:infra/mcp/render_bridge.py†L16-L17】【F:infra/mcp/render_bridge.py†L94-L136】 |
+
+Once the CLI is connected you can take advantage of Render’s mechanistic build,
+Cloudflare’s KV/D1 caching layer, and the Hugging Face Space simultaneously from
+a single MCP session.

--- a/infra/__init__.py
+++ b/infra/__init__.py
@@ -1,0 +1,3 @@
+"""Infrastructure automation helpers for Neuropharm Simulation Lab."""
+
+__all__ = []

--- a/infra/mcp/__init__.py
+++ b/infra/mcp/__init__.py
@@ -1,0 +1,10 @@
+"""Model Context Protocol utilities for Neuropharm Simulation Lab."""
+
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("neuropharm-sim-lab-mcp")
+except PackageNotFoundError:  # pragma: no cover - package metadata only when installed
+    __version__ = "0.0.0"
+
+__all__ = ["__version__"]

--- a/infra/mcp/render_bridge.py
+++ b/infra/mcp/render_bridge.py
@@ -1,0 +1,249 @@
+"""STDIO MCP server that proxies Neuropharm deployments hosted on Render and Cloudflare."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Mapping, Optional
+from urllib.parse import urljoin
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+DEFAULT_TIMEOUT_SECONDS = float(os.getenv("NEUROPHARM_MCP_TIMEOUT", "120"))
+USER_AGENT = "neuropharm-mcp-bridge/0.1"
+
+mcp = FastMCP(
+    "Neuropharm Render Bridge",
+    instructions=(
+        "Proxy Neuropharm Simulation Lab deployments hosted on Render, Cloudflare, "
+        "and Hugging Face. Configure NEUROPHARM_RENDER_URL, NEUROPHARM_WORKER_URL, "
+        "or NEUROPHARM_HF_URL before launching the bridge."
+    ),
+)
+
+_ENV_TARGETS: tuple[tuple[str, str], ...] = (
+    ("render", "NEUROPHARM_RENDER_URL"),
+    ("worker", "NEUROPHARM_WORKER_URL"),
+    ("huggingface", "NEUROPHARM_HF_URL"),
+    ("local", "NEUROPHARM_LOCAL_URL"),
+)
+
+
+def _available_targets() -> Dict[str, str]:
+    """Return the configured target base URLs keyed by name."""
+
+    mapping: Dict[str, str] = {}
+    for key, env_name in _ENV_TARGETS:
+        value = os.getenv(env_name)
+        if value:
+            mapping[key] = value.rstrip("/")
+    if not mapping:
+        mapping["local"] = os.getenv("NEUROPHARM_FALLBACK_URL", "http://127.0.0.1:8000").rstrip("/")
+    return mapping
+
+
+def _select_target(explicit: Optional[str] = None) -> tuple[str, str]:
+    """Resolve the target identifier and base URL to use for a request."""
+
+    targets = _available_targets()
+    if explicit:
+        key = explicit.lower()
+        if key not in targets:
+            raise ValueError(
+                f"Unknown target '{explicit}'. Available targets: {', '.join(sorted(targets))}."
+            )
+        return key, targets[key]
+
+    preferred = os.getenv("NEUROPHARM_DEFAULT_TARGET")
+    if preferred and preferred.lower() in targets:
+        key = preferred.lower()
+        return key, targets[key]
+
+    for key, _env_name in _ENV_TARGETS:
+        if key in targets:
+            return key, targets[key]
+
+    key = next(iter(targets))
+    return key, targets[key]
+
+
+def _load_shared_headers() -> Dict[str, str]:
+    """Build common HTTP headers, including optional API key injection."""
+
+    headers: Dict[str, str] = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+
+    shared_token = os.getenv("NEUROPHARM_API_KEY")
+    if shared_token:
+        headers.setdefault("Authorization", f"Bearer {shared_token}")
+
+    extra_json = os.getenv("NEUROPHARM_EXTRA_HEADERS_JSON")
+    if extra_json:
+        try:
+            extra = json.loads(extra_json)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive path
+            raise ValueError(
+                "NEUROPHARM_EXTRA_HEADERS_JSON must contain a JSON object"
+            ) from exc
+        if not isinstance(extra, Mapping):
+            raise ValueError("NEUROPHARM_EXTRA_HEADERS_JSON must decode to an object")
+        headers.update({str(k): str(v) for k, v in extra.items()})
+
+    return headers
+
+
+def _target_specific_headers(target: str) -> Dict[str, str]:
+    """Apply target-specific overrides (API keys or additional headers)."""
+
+    headers: Dict[str, str] = {}
+    token_env = f"NEUROPHARM_{target.upper()}_API_KEY"
+    token = os.getenv(token_env)
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    extra_env = f"NEUROPHARM_{target.upper()}_HEADERS_JSON"
+    extra_json = os.getenv(extra_env)
+    if extra_json:
+        try:
+            extra = json.loads(extra_json)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive path
+            raise ValueError(f"{extra_env} must contain a JSON object") from exc
+        if not isinstance(extra, Mapping):
+            raise ValueError(f"{extra_env} must decode to an object")
+        headers.update({str(k): str(v) for k, v in extra.items()})
+
+    return headers
+
+
+def _compose_headers(target: str) -> Dict[str, str]:
+    headers = _load_shared_headers()
+    headers.update(_target_specific_headers(target))
+    return headers
+
+
+def _make_url(base: str, path: str) -> str:
+    if not path.startswith("/"):
+        path = "/" + path
+    return urljoin(base + "/", path.lstrip("/"))
+
+
+def _serialize_response(response: httpx.Response, target: str, url: str) -> Dict[str, Any]:
+    body: Dict[str, Any]
+    try:
+        body = {"json": response.json()}
+    except ValueError:
+        body = {"text": response.text}
+    return {
+        "target": target,
+        "url": url,
+        "status_code": response.status_code,
+        "ok": response.is_success,
+        "headers": {k: v for k, v in response.headers.items() if k.lower() in {"content-type", "cf-cache-status", "server"}},
+        "body": body,
+    }
+
+
+async def _issue_request(
+    method: str,
+    path: str,
+    *,
+    target: Optional[str] = None,
+    query: Optional[Dict[str, Any]] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    timeout_seconds: Optional[float] = None,
+) -> Dict[str, Any]:
+    name, base = _select_target(target)
+    url = _make_url(base, path)
+    headers = _compose_headers(name)
+    timeout = timeout_seconds or DEFAULT_TIMEOUT_SECONDS
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.request(
+            method.upper(),
+            url,
+            params=query,
+            json=payload,
+            headers=headers,
+        )
+    payload_summary = _serialize_response(response, name, url)
+    if not response.is_success:
+        payload_summary["error"] = response.text
+    return payload_summary
+
+
+@mcp.tool(name="neuropharm.list_targets")
+def list_targets() -> Dict[str, Any]:
+    """List configured deployment targets and the active default selection."""
+
+    targets = _available_targets()
+    default_name, default_url = _select_target()
+    return {
+        "targets": targets,
+        "default": {"name": default_name, "url": default_url},
+        "environment": {
+            env: os.getenv(env)
+            for _key, env in _ENV_TARGETS
+            if os.getenv(env)
+        },
+    }
+
+
+@mcp.tool(name="neuropharm.fetch_capabilities")
+async def fetch_capabilities(
+    target: Optional[str] = None,
+    timeout_seconds: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Retrieve the ``/assistant/capabilities`` payload from a deployment."""
+
+    return await _issue_request(
+        "GET",
+        "/assistant/capabilities",
+        target=target,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+@mcp.tool(name="neuropharm.execute_action")
+async def execute_action(
+    action: str,
+    payload: Optional[Dict[str, Any]] = None,
+    *,
+    target: Optional[str] = None,
+    timeout_seconds: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Execute an assistant workflow by proxying ``/assistant/execute``."""
+
+    request_payload = {"action": action, "payload": payload or {}}
+    return await _issue_request(
+        "POST",
+        "/assistant/execute",
+        target=target,
+        payload=request_payload,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+@mcp.tool(name="neuropharm.raw_request")
+async def raw_request(
+    method: str,
+    path: str,
+    *,
+    target: Optional[str] = None,
+    query: Optional[Dict[str, Any]] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    timeout_seconds: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Send an arbitrary HTTP request to the selected deployment."""
+
+    return await _issue_request(
+        method,
+        path,
+        target=target,
+        query=query,
+        payload=payload,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/infra/mcp/requirements.txt
+++ b/infra/mcp/requirements.txt
@@ -1,0 +1,4 @@
+mcp>=1.15.0
+mcp-cli>=0.7.5
+httpx>=0.28.1
+python-dotenv>=1.0.1

--- a/infra/mcp/server_config.json
+++ b/infra/mcp/server_config.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "neuropharm-render": {
+      "command": "python",
+      "args": ["-m", "infra.mcp.render_bridge"],
+      "env": {
+        "NEUROPHARM_RENDER_URL": "https://<your-render-service>.onrender.com",
+        "NEUROPHARM_WORKER_URL": "https://<your-worker-subdomain>.workers.dev",
+        "NEUROPHARM_HF_URL": "https://<your-space>.hf.space",
+        "NEUROPHARM_DEFAULT_TARGET": "worker"
+      }
+    }
+  },
+  "toolSettings": {
+    "defaultTimeout": 180.0,
+    "maxConcurrency": 4
+  }
+}


### PR DESCRIPTION
## Summary
- add an MCP bridge server that proxies Render/Cloudflare/HF deployments for mcp-cli usage
- bundle configuration and dependency templates so the bridge can be launched quickly
- document the end-to-end workflow for using mcp-cli alongside the existing deployment guide

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8fafba6e48329a426b94ed5fd70e4