### PR TITLE
Remove OSPSuite optional dependency

### DIFF
--- a/backend/requirements-optional.txt
+++ b/backend/requirements-optional.txt
@@ -1,7 +1,6 @@
 # Simulation backends that require platform-specific dependencies.
 # Install selectively when you need the PySB/OSP Suite/TVB integrations.
 pysb>=1.13.0
-ospsuite>=11.0.0
 tvb-library>=2.8.0
 
 # Causal inference add-ons for counterfactual diagnostics.


### PR DESCRIPTION
## Summary
- remove the OSPSuite package from the optional backend requirements so the image builds with PyPI-only dependencies

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d93f83c60483299d86a75d7ccf8849