### PR TITLE
Fix assumption graph label escaping

### DIFF
--- a/backend/graph/service.py
+++ b/backend/graph/service.py
@@ -296,7 +296,8 @@ class GraphService:
             return f'"{escaped}"'
 
         def node_definition(node_id: str, *, latent: bool) -> str:
-            attrs = [f"label=\"{self._label_for_node(node_id).replace('\"', '\\\"')}\""]
+            label = self._label_for_node(node_id).replace("\"", "\\\"")
+            attrs = [f'label="{label}"']
             if latent:
                 attrs.append("latent=\"yes\"")
             return f"  {quote(node_id)} [{', '.join(attrs)}];"


### PR DESCRIPTION
## Summary
- cache the escaped node label in _build_assumption_graph helper
- reuse the cached label when assembling the DOT attributes to avoid inline escapes

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d94aea45c48329a499d2724530e8b1