### PR TITLE
Align Worker bindings with docs and bundle Hugging Face helper files

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -35,14 +35,8 @@ Hugging Face Spaces lets you run the backend on free hardware tiers.
 1. Create a new **Space** and pick **FastAPI** as the template.
 2. Upload these files into the Space:
    - `backend/` directory (you can copy the whole folder or zip and upload it).
-   - A short entry script named `app.py` that imports the FastAPI app:
-     ```python
-     from backend.main import app
-     ```
-   - `requirements.txt` that simply references the backend requirements:
-     ```text
-     -r backend/requirements.txt
-     ```
+   - The helper files from `hf_space/` (`app.py` and `requirements.txt`) which already contain the correct import and dependency
+     references.
 3. In the Space **Settings → Variables and secrets**, add the same environment variables used on Render (`GRAPH_*`, `VECTOR_DB_URL`, etc.).
 4. Click **Restart**. The Space will rebuild, install the requirements, and expose a public URL such as `https://<space-owner>-<space-name>.hf.space`.
 5. Open `https://<space-url>/assistant/capabilities` in a browser to confirm the API is live.
@@ -62,10 +56,12 @@ Deploy the Worker once you have a reachable backend (Render, Hugging Face, or an
    ```
 2. Create the storage bindings:
    ```bash
-   npx wrangler kv:namespace create neuropharm-config
+   npx wrangler kv namespace create neuropharm-config
    npx wrangler d1 create neuropharm-vector-cache
    ```
-   Copy the generated IDs into `wrangler.toml` under the `kv_namespaces` and `d1_databases` sections.
+   Copy the generated IDs into `wrangler.toml` under the `kv_namespaces` and `d1_databases` sections. The Worker expects the KV
+   binding to be named `NEUROPHARM_CONFIG` and the D1 binding to be `VECTOR_CACHE`, both already declared in the template
+   `wrangler.toml` file.
 3. Seed secrets and default variables:
    ```bash
    npx wrangler secret put API_BASE_URL      # e.g. https://your-render-service.onrender.com

--- a/hf_space/app.py
+++ b/hf_space/app.py
@@ -1,0 +1,7 @@
+"""Entry point for the Hugging Face Space deployment.
+
+This file simply re-exports the FastAPI application from the backend so the
+Space runtime can discover and serve it.
+"""
+
+from backend.main import app

--- a/hf_space/requirements.txt
+++ b/hf_space/requirements.txt
@@ -1,0 +1,1 @@
+-r backend/requirements.txt

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,7 +1,7 @@
 export interface Env {
   API_BASE_URL?: string;
   CACHE_TTL_SECONDS?: string;
-  CONFIG_KV?: KVNamespace;
+  NEUROPHARM_CONFIG?: KVNamespace;
   VECTOR_CACHE?: D1Database;
 }
 
@@ -15,7 +15,7 @@ async function resolveBackendBase(env: Env): Promise<string | null> {
     return direct;
   }
   try {
-    const kvValue = await env.CONFIG_KV?.get("api_base_url");
+    const kvValue = await env.NEUROPHARM_CONFIG?.get("api_base_url");
     if (kvValue && kvValue.trim()) {
       return kvValue.trim();
     }
@@ -145,7 +145,7 @@ function buildHealthPayload(env: Env, backendBase: string | null): Response {
     status: "ok",
     backend: backendBase,
     cache: env.VECTOR_CACHE ? "enabled" : "disabled",
-    configNamespace: env.CONFIG_KV ? "bound" : "unbound",
+    configNamespace: env.NEUROPHARM_CONFIG ? "bound" : "unbound",
   };
   return new Response(JSON.stringify(payload), {
     status: 200,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,8 +8,8 @@ API_BASE_URL = "http://127.0.0.1:8000"
 CACHE_TTL_SECONDS = "60"
 
 [[kv_namespaces]]
-binding = "CONFIG_KV"
-# Replace the values below after creating the namespace via `wrangler kv:namespace create`.
+binding = "NEUROPHARM_CONFIG"
+# Replace the values below after creating the namespace via `wrangler kv namespace create`.
 id = "<YOUR_KV_NAMESPACE_ID>"
 preview_id = "<YOUR_KV_PREVIEW_ID>"
 


### PR DESCRIPTION
## Summary
- rename the Cloudflare Worker KV binding to `NEUROPHARM_CONFIG` and update the health output
- refresh the deployment guide with the new Wrangler commands and reference helper assets
- add an `hf_space` folder with the Space entrypoint and requirements for easy uploads

## Testing
- python -m compileall backend/main.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db6035602c832994afb76973e1c78d